### PR TITLE
Implement support for ppc64 ELFv2

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -4,3 +4,4 @@
 # some cases, their employer may be the copyright holder.  To see the full list
 # of contributors, see the revision history in source control.
 Google LLC
+Shawn Anastasio <shawn@anastas.io>

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Marl is a C++ 11 library that provides a fluent interface for running tasks acro
 
 Marl uses a combination of fibers and threads to allow efficient execution of tasks that can block, while keeping a fixed number of hardware threads.
 
-Marl supports Windows, macOS, Linux, Fuchsia and Android (arm, aarch64, x86 and x64).
+Marl supports Windows, macOS, Linux, Fuchsia and Android (arm, aarch64, ppc64 (ELFv2), x86 and x64).
 
 Marl has no dependencies on other libraries (with exception on googletest fo building the optional unit tests).
 

--- a/src/osfiber_asm.h
+++ b/src/osfiber_asm.h
@@ -30,6 +30,8 @@
 #include "osfiber_asm_aarch64.h"
 #elif defined(__arm__)
 #include "osfiber_asm_arm.h"
+#elif defined(__powerpc64__)
+#include "osfiber_asm_ppc64.h"
 #else
 #error "Unsupported target"
 #endif

--- a/src/osfiber_asm_ppc64.S
+++ b/src/osfiber_asm_ppc64.S
@@ -1,0 +1,192 @@
+// Copyright 2019 The Marl Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#if defined(__powerpc64__)
+
+#define MARL_BUILD_ASM 1
+#include "osfiber_asm_ppc64.h"
+
+// void marl_fiber_swap(marl_fiber_context* from, const marl_fiber_context* to)
+// r3: from
+// r4: to
+.text
+.global marl_fiber_swap
+.align 4
+.type marl_fiber_swap @function
+marl_fiber_swap:
+
+    // Store non-volatile registers
+    std 1, MARL_REG_R1(3)
+    std 2, MARL_REG_R2(3)
+    std 13, MARL_REG_R13(3)
+    std 14, MARL_REG_R14(3)
+    std 15, MARL_REG_R15(3)
+    std 16, MARL_REG_R16(3)
+    std 17, MARL_REG_R17(3)
+    std 18, MARL_REG_R18(3)
+    std 19, MARL_REG_R19(3)
+    std 20, MARL_REG_R20(3)
+    std 21, MARL_REG_R21(3)
+    std 22, MARL_REG_R22(3)
+    std 23, MARL_REG_R23(3)
+    std 24, MARL_REG_R24(3)
+    std 25, MARL_REG_R25(3)
+    std 26, MARL_REG_R26(3)
+    std 27, MARL_REG_R27(3)
+    std 28, MARL_REG_R28(3)
+    std 29, MARL_REG_R29(3)
+    std 30, MARL_REG_R30(3)
+    std 31, MARL_REG_R31(3)
+
+    // Store special registers
+    mflr 5
+    std 5, MARL_REG_LR(3)
+    mfcr 5
+    std 5, MARL_REG_CCR(3)
+
+    // Store non-volatile floating point registers
+    stfd 14, MARL_REG_FPR14(3)
+    stfd 15, MARL_REG_FPR15(3)
+    stfd 16, MARL_REG_FPR16(3)
+    stfd 17, MARL_REG_FPR17(3)
+    stfd 18, MARL_REG_FPR18(3)
+    stfd 19, MARL_REG_FPR19(3)
+    stfd 20, MARL_REG_FPR20(3)
+    stfd 21, MARL_REG_FPR21(3)
+    stfd 22, MARL_REG_FPR22(3)
+    stfd 23, MARL_REG_FPR23(3)
+    stfd 24, MARL_REG_FPR24(3)
+    stfd 25, MARL_REG_FPR25(3)
+    stfd 26, MARL_REG_FPR26(3)
+    stfd 27, MARL_REG_FPR27(3)
+    stfd 28, MARL_REG_FPR28(3)
+    stfd 29, MARL_REG_FPR29(3)
+    stfd 30, MARL_REG_FPR30(3)
+    stfd 31, MARL_REG_FPR31(3)
+
+    // Store non-volatile altivec registers
+#ifdef __ALTIVEC__
+    li 5, MARL_REG_VMX
+    stvxl 20, 3, 5
+    addi 5, 5, 16
+    stvxl 21, 3, 5
+    addi 5, 5, 16
+    stvxl 22, 3, 5
+    addi 5, 5, 16
+    stvxl 23, 3, 5
+    addi 5, 5, 16
+    stvxl 24, 3, 5
+    addi 5, 5, 16
+    stvxl 25, 3, 5
+    addi 5, 5, 16
+    stvxl 26, 3, 5
+    addi 5, 5, 16
+    stvxl 27, 3, 5
+    addi 5, 5, 16
+    stvxl 28, 3, 5
+    addi 5, 5, 16
+    stvxl 29, 3, 5
+    addi 5, 5, 16
+    stvxl 30, 3, 5
+    addi 5, 5, 16
+    stvxl 31, 3, 5
+
+    mfvrsave 5
+    stw 5, MARL_REG_VRSAVE(3)
+#endif // __ALTIVEC__
+
+    // Load non-volatile registers
+    ld 1, MARL_REG_R1(4)
+    ld 2, MARL_REG_R2(4)
+    ld 13, MARL_REG_R13(4)
+    ld 14, MARL_REG_R14(4)
+    ld 15, MARL_REG_R15(4)
+    ld 16, MARL_REG_R16(4)
+    ld 17, MARL_REG_R17(4)
+    ld 18, MARL_REG_R18(4)
+    ld 19, MARL_REG_R19(4)
+    ld 20, MARL_REG_R20(4)
+    ld 21, MARL_REG_R21(4)
+    ld 22, MARL_REG_R22(4)
+    ld 23, MARL_REG_R23(4)
+    ld 24, MARL_REG_R24(4)
+    ld 25, MARL_REG_R25(4)
+    ld 26, MARL_REG_R26(4)
+    ld 27, MARL_REG_R27(4)
+    ld 28, MARL_REG_R28(4)
+    ld 29, MARL_REG_R29(4)
+    ld 30, MARL_REG_R30(4)
+    ld 31, MARL_REG_R31(4)
+
+    // Load non-volatile floating point registers
+    lfd 14, MARL_REG_FPR14(4)
+    lfd 15, MARL_REG_FPR15(4)
+    lfd 16, MARL_REG_FPR16(4)
+    lfd 17, MARL_REG_FPR17(4)
+    lfd 18, MARL_REG_FPR18(4)
+    lfd 19, MARL_REG_FPR19(4)
+    lfd 20, MARL_REG_FPR20(4)
+    lfd 21, MARL_REG_FPR21(4)
+    lfd 22, MARL_REG_FPR22(4)
+    lfd 23, MARL_REG_FPR23(4)
+    lfd 24, MARL_REG_FPR24(4)
+    lfd 25, MARL_REG_FPR25(4)
+    lfd 26, MARL_REG_FPR26(4)
+    lfd 27, MARL_REG_FPR27(4)
+    lfd 28, MARL_REG_FPR28(4)
+    lfd 29, MARL_REG_FPR29(4)
+    lfd 30, MARL_REG_FPR30(4)
+    lfd 31, MARL_REG_FPR31(4)
+
+    // Load non-volatile altivec registers
+#ifdef __ALTIVEC__
+    li 5, MARL_REG_VMX
+    lvxl 20, 4, 5
+    addi 5, 5, 16
+    lvxl 21, 4, 5
+    addi 5, 5, 16
+    lvxl 22, 4, 5
+    addi 5, 5, 16
+    lvxl 23, 4, 5
+    addi 5, 5, 16
+    lvxl 24, 4, 5
+    addi 5, 5, 16
+    lvxl 25, 4, 5
+    addi 5, 5, 16
+    lvxl 26, 4, 5
+    addi 5, 5, 16
+    lvxl 27, 4, 5
+    addi 5, 5, 16
+    lvxl 28, 4, 5
+    addi 5, 5, 16
+    lvxl 29, 4, 5
+    addi 5, 5, 16
+    lvxl 30, 4, 5
+    addi 5, 5, 16
+    lvxl 31, 4, 5
+
+    lwz 5, MARL_REG_VRSAVE(4)
+    mtvrsave 5
+#endif // __ALTIVEC__
+
+    // Load parameters and entrypoint
+    ld 12, MARL_REG_LR(4)
+    ld 3, MARL_REG_R3(4)
+    ld 4, MARL_REG_R4(4)
+    mtlr 12
+
+    // Branch to entrypoint
+    blr
+
+#endif // defined(__powerpc64__)

--- a/src/osfiber_asm_ppc64.h
+++ b/src/osfiber_asm_ppc64.h
@@ -1,0 +1,223 @@
+// Copyright 2019 The Marl Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#define MARL_REG_R1 0x00
+#define MARL_REG_R2 0x08
+#define MARL_REG_R13 0x10
+#define MARL_REG_R14 0x18
+#define MARL_REG_R15 0x20
+#define MARL_REG_R16 0x28
+#define MARL_REG_R17 0x30
+#define MARL_REG_R18 0x38
+#define MARL_REG_R19 0x40
+#define MARL_REG_R20 0x48
+#define MARL_REG_R21 0x50
+#define MARL_REG_R22 0x58
+#define MARL_REG_R23 0x60
+#define MARL_REG_R24 0x68
+#define MARL_REG_R25 0x70
+#define MARL_REG_R26 0x78
+#define MARL_REG_R27 0x80
+#define MARL_REG_R28 0x88
+#define MARL_REG_R29 0x90
+#define MARL_REG_R30 0x98
+#define MARL_REG_R31 0xa0
+
+#define MARL_REG_R3 0xa8
+#define MARL_REG_R4 0xb0
+
+#define MARL_REG_LR 0xb8
+#define MARL_REG_CCR 0xc0
+
+#define MARL_REG_FPR14 0xc8
+#define MARL_REG_FPR15 0xd0
+#define MARL_REG_FPR16 0xd8
+#define MARL_REG_FPR17 0xe0
+#define MARL_REG_FPR18 0xe8
+#define MARL_REG_FPR19 0xf0
+#define MARL_REG_FPR20 0xf8
+#define MARL_REG_FPR21 0x100
+#define MARL_REG_FPR22 0x108
+#define MARL_REG_FPR23 0x110
+#define MARL_REG_FPR24 0x118
+#define MARL_REG_FPR25 0x120
+#define MARL_REG_FPR26 0x128
+#define MARL_REG_FPR27 0x130
+#define MARL_REG_FPR28 0x138
+#define MARL_REG_FPR29 0x140
+#define MARL_REG_FPR30 0x148
+#define MARL_REG_FPR31 0x150
+
+#define MARL_REG_VRSAVE 0x158
+#define MARL_REG_VMX 0x160
+
+#ifndef MARL_BUILD_ASM
+
+#include <stdint.h>
+
+struct marl_fiber_context {
+  // non-volatile registers
+  uintptr_t r1;
+  uintptr_t r2;
+  uintptr_t r13;
+  uintptr_t r14;
+  uintptr_t r15;
+  uintptr_t r16;
+  uintptr_t r17;
+  uintptr_t r18;
+  uintptr_t r19;
+  uintptr_t r20;
+  uintptr_t r21;
+  uintptr_t r22;
+  uintptr_t r23;
+  uintptr_t r24;
+  uintptr_t r25;
+  uintptr_t r26;
+  uintptr_t r27;
+  uintptr_t r28;
+  uintptr_t r29;
+  uintptr_t r30;
+  uintptr_t r31;
+
+  // first two parameter registers (r3, r4)
+  uintptr_t r3;
+  uintptr_t r4;
+
+  // special registers
+  uintptr_t lr;
+  uintptr_t ccr;
+
+  // non-volatile floating-point registers (f14-f31)
+  uintptr_t fpr14;
+  uintptr_t fpr15;
+  uintptr_t fpr16;
+  uintptr_t fpr17;
+  uintptr_t fpr18;
+  uintptr_t fpr19;
+  uintptr_t fpr20;
+  uintptr_t fpr21;
+  uintptr_t fpr22;
+  uintptr_t fpr23;
+  uintptr_t fpr24;
+  uintptr_t fpr25;
+  uintptr_t fpr26;
+  uintptr_t fpr27;
+  uintptr_t fpr28;
+  uintptr_t fpr29;
+  uintptr_t fpr30;
+  uintptr_t fpr31;
+
+  // non-volatile altivec registers
+  uint32_t vrsave;
+  uintptr_t vmx[12 * 2];
+};
+
+// Only the ELFv2 ABI is supported for now.
+#if !defined(_CALL_ELF) || (_CALL_ELF != 2)
+#error "Only the ppc64 ELFv2 ABI is supported."
+#endif
+
+#ifdef __cplusplus
+#include <cstddef>
+static_assert(offsetof(marl_fiber_context, r1) == MARL_REG_R1,
+              "Bad register offset");
+static_assert(offsetof(marl_fiber_context, r2) == MARL_REG_R2,
+              "Bad register offset");
+static_assert(offsetof(marl_fiber_context, r13) == MARL_REG_R13,
+              "Bad register offset");
+static_assert(offsetof(marl_fiber_context, r15) == MARL_REG_R15,
+              "Bad register offset");
+static_assert(offsetof(marl_fiber_context, r16) == MARL_REG_R16,
+              "Bad register offset");
+static_assert(offsetof(marl_fiber_context, r17) == MARL_REG_R17,
+              "Bad register offset");
+static_assert(offsetof(marl_fiber_context, r18) == MARL_REG_R18,
+              "Bad register offset");
+static_assert(offsetof(marl_fiber_context, r19) == MARL_REG_R19,
+              "Bad register offset");
+static_assert(offsetof(marl_fiber_context, r20) == MARL_REG_R20,
+              "Bad register offset");
+static_assert(offsetof(marl_fiber_context, r21) == MARL_REG_R21,
+              "Bad register offset");
+static_assert(offsetof(marl_fiber_context, r22) == MARL_REG_R22,
+              "Bad register offset");
+static_assert(offsetof(marl_fiber_context, r23) == MARL_REG_R23,
+              "Bad register offset");
+static_assert(offsetof(marl_fiber_context, r24) == MARL_REG_R24,
+              "Bad register offset");
+static_assert(offsetof(marl_fiber_context, r25) == MARL_REG_R25,
+              "Bad register offset");
+static_assert(offsetof(marl_fiber_context, r26) == MARL_REG_R26,
+              "Bad register offset");
+static_assert(offsetof(marl_fiber_context, r27) == MARL_REG_R27,
+              "Bad register offset");
+static_assert(offsetof(marl_fiber_context, r28) == MARL_REG_R28,
+              "Bad register offset");
+static_assert(offsetof(marl_fiber_context, r29) == MARL_REG_R29,
+              "Bad register offset");
+static_assert(offsetof(marl_fiber_context, r30) == MARL_REG_R30,
+              "Bad register offset");
+static_assert(offsetof(marl_fiber_context, r31) == MARL_REG_R31,
+              "Bad register offset");
+static_assert(offsetof(marl_fiber_context, r14) == MARL_REG_R14,
+              "Bad register offset");
+static_assert(offsetof(marl_fiber_context, lr) == MARL_REG_LR,
+              "Bad register offset");
+static_assert(offsetof(marl_fiber_context, ccr) == MARL_REG_CCR,
+              "Bad register offset");
+static_assert(offsetof(marl_fiber_context, fpr14) == MARL_REG_FPR14,
+              "Bad register offset");
+static_assert(offsetof(marl_fiber_context, fpr15) == MARL_REG_FPR15,
+              "Bad register offset");
+static_assert(offsetof(marl_fiber_context, fpr16) == MARL_REG_FPR16,
+              "Bad register offset");
+static_assert(offsetof(marl_fiber_context, fpr17) == MARL_REG_FPR17,
+              "Bad register offset");
+static_assert(offsetof(marl_fiber_context, fpr18) == MARL_REG_FPR18,
+              "Bad register offset");
+static_assert(offsetof(marl_fiber_context, fpr19) == MARL_REG_FPR19,
+              "Bad register offset");
+static_assert(offsetof(marl_fiber_context, fpr20) == MARL_REG_FPR20,
+              "Bad register offset");
+static_assert(offsetof(marl_fiber_context, fpr21) == MARL_REG_FPR21,
+              "Bad register offset");
+static_assert(offsetof(marl_fiber_context, fpr22) == MARL_REG_FPR22,
+              "Bad register offset");
+static_assert(offsetof(marl_fiber_context, fpr23) == MARL_REG_FPR23,
+              "Bad register offset");
+static_assert(offsetof(marl_fiber_context, fpr24) == MARL_REG_FPR24,
+              "Bad register offset");
+static_assert(offsetof(marl_fiber_context, fpr25) == MARL_REG_FPR25,
+              "Bad register offset");
+static_assert(offsetof(marl_fiber_context, fpr26) == MARL_REG_FPR26,
+              "Bad register offset");
+static_assert(offsetof(marl_fiber_context, fpr27) == MARL_REG_FPR27,
+              "Bad register offset");
+static_assert(offsetof(marl_fiber_context, fpr28) == MARL_REG_FPR28,
+              "Bad register offset");
+static_assert(offsetof(marl_fiber_context, fpr29) == MARL_REG_FPR29,
+              "Bad register offset");
+static_assert(offsetof(marl_fiber_context, fpr30) == MARL_REG_FPR30,
+              "Bad register offset");
+static_assert(offsetof(marl_fiber_context, fpr31) == MARL_REG_FPR31,
+              "Bad register offset");
+static_assert((offsetof(marl_fiber_context, vmx) % 16) == 0,
+              "VMX must be quadword aligned");
+static_assert(offsetof(marl_fiber_context, vmx) == MARL_REG_VMX,
+              "Bad register offset");
+static_assert(offsetof(marl_fiber_context, vrsave) == MARL_REG_VRSAVE,
+              "Bad register offset");
+#endif  // __cplusplus
+
+#endif  // MARL_BUILD_ASM

--- a/src/osfiber_ppc64.c
+++ b/src/osfiber_ppc64.c
@@ -1,0 +1,47 @@
+// Copyright 2019 The Marl Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#if defined(__powerpc64__)
+
+#include "osfiber_asm_ppc64.h"
+
+void marl_fiber_trampoline(void (*target)(void*), void* arg) {
+  target(arg);
+}
+
+void marl_fiber_set_target(struct marl_fiber_context* ctx,
+                           void* stack,
+                           uint32_t stack_size,
+                           void (*target)(void*),
+                           void* arg) {
+  uintptr_t stack_top = (uintptr_t)((uint8_t*)(stack) + stack_size);
+  if ((stack_top % 16) != 0)
+    stack_top -= (stack_top % 16);
+
+  // Write a backchain and subtract a minimum stack frame size (32)
+  *(uintptr_t*)stack_top = 0;
+  stack_top -= 32;
+  *(uintptr_t*)stack_top = stack_top + 32;
+
+  // Load registers
+  ctx->r1 = stack_top;
+  ctx->lr = (uintptr_t)marl_fiber_trampoline;
+  ctx->r3 = (uintptr_t)target;
+  ctx->r4 = (uintptr_t)arg;
+
+  // Thread pointer must be saved in r13
+  __asm__ volatile("mr %0, 13\n" : "=r"(ctx->r13));
+}
+
+#endif  // __powerpc64__


### PR DESCRIPTION
This commit adds Yarn support for powerpc64 machines
using the ELFv2 ABI. The changes have been tested on
a POWER9 machine running in Little Endian mode and all
unit tests pass.