### PR TITLE
Switch copyright headers from 'Google LLC' to authors file

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,0 +1,6 @@
+# This is the list of the Marl authors for copyright purposes.
+#
+# This does not necessarily list everyone who has contributed code, since in
+# some cases, their employer may be the copyright holder.  To see the full list
+# of contributors, see the revision history in source control.
+Google LLC

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2019 Google LLC
+# Copyright 2019 The Marl Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/include/marl/blockingcall.h
+++ b/include/marl/blockingcall.h
@@ -1,4 +1,4 @@
-// Copyright 2019 The SwiftShader Authors. All Rights Reserved.
+// Copyright 2019 The Marl Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/marl/conditionvariable.h
+++ b/include/marl/conditionvariable.h
@@ -1,4 +1,4 @@
-// Copyright 2019 Google LLC
+// Copyright 2019 The Marl Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/marl/containers.h
+++ b/include/marl/containers.h
@@ -1,4 +1,4 @@
-// Copyright 2019 Google LLC
+// Copyright 2019 The Marl Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/marl/debug.h
+++ b/include/marl/debug.h
@@ -1,4 +1,4 @@
-// Copyright 2019 Google LLC
+// Copyright 2019 The Marl Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/marl/defer.h
+++ b/include/marl/defer.h
@@ -1,4 +1,4 @@
-// Copyright 2019 Google LLC
+// Copyright 2019 The Marl Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/marl/finally.h
+++ b/include/marl/finally.h
@@ -1,4 +1,4 @@
-// Copyright 2019 Google LLC
+// Copyright 2019 The Marl Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/marl/pool.h
+++ b/include/marl/pool.h
@@ -1,4 +1,4 @@
-// Copyright 2019 Google LLC
+// Copyright 2019 The Marl Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/marl/sal.h
+++ b/include/marl/sal.h
@@ -1,4 +1,4 @@
-// Copyright 2019 Google LLC
+// Copyright 2019 The Marl Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/marl/scheduler.h
+++ b/include/marl/scheduler.h
@@ -1,4 +1,4 @@
-// Copyright 2019 Google LLC
+// Copyright 2019 The Marl Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/marl/thread.h
+++ b/include/marl/thread.h
@@ -1,4 +1,4 @@
-// Copyright 2019 Google LLC
+// Copyright 2019 The Marl Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/marl/ticket.h
+++ b/include/marl/ticket.h
@@ -1,4 +1,4 @@
-// Copyright 2019 Google LLC
+// Copyright 2019 The Marl Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/marl/trace.h
+++ b/include/marl/trace.h
@@ -1,4 +1,4 @@
-// Copyright 2019 Google LLC
+// Copyright 2019 The Marl Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/marl/utils.h
+++ b/include/marl/utils.h
@@ -1,4 +1,4 @@
-// Copyright 2019 Google LLC
+// Copyright 2019 The Marl Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/include/marl/waitgroup.h
+++ b/include/marl/waitgroup.h
@@ -1,4 +1,4 @@
-// Copyright 2019 Google LLC
+// Copyright 2019 The Marl Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/blockingcall_test.cpp
+++ b/src/blockingcall_test.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019 Google LLC
+// Copyright 2019 The Marl Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/conditionvariable_test.cpp
+++ b/src/conditionvariable_test.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019 Google LLC
+// Copyright 2019 The Marl Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/containers_test.cpp
+++ b/src/containers_test.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019 Google LLC
+// Copyright 2019 The Marl Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/debug.cpp
+++ b/src/debug.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019 Google LLC
+// Copyright 2019 The Marl Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/defer_test.cpp
+++ b/src/defer_test.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019 Google LLC
+// Copyright 2019 The Marl Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/marl_test.cpp
+++ b/src/marl_test.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019 Google LLC
+// Copyright 2019 The Marl Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/marl_test.h
+++ b/src/marl_test.h
@@ -1,4 +1,4 @@
-// Copyright 2019 Google LLC
+// Copyright 2019 The Marl Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/osfiber.h
+++ b/src/osfiber.h
@@ -1,4 +1,4 @@
-// Copyright 2019 Google LLC
+// Copyright 2019 The Marl Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/osfiber_aarch64.c
+++ b/src/osfiber_aarch64.c
@@ -1,4 +1,4 @@
-// Copyright 2019 Google LLC
+// Copyright 2019 The Marl Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/osfiber_arm.c
+++ b/src/osfiber_arm.c
@@ -1,4 +1,4 @@
-// Copyright 2019 Google LLC
+// Copyright 2019 The Marl Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/osfiber_asm.h
+++ b/src/osfiber_asm.h
@@ -1,4 +1,4 @@
-// Copyright 2019 Google LLC
+// Copyright 2019 The Marl Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/osfiber_asm_aarch64.S
+++ b/src/osfiber_asm_aarch64.S
@@ -1,4 +1,4 @@
-// Copyright 2019 Google LLC
+// Copyright 2019 The Marl Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/osfiber_asm_aarch64.h
+++ b/src/osfiber_asm_aarch64.h
@@ -1,4 +1,4 @@
-// Copyright 2019 Google LLC
+// Copyright 2019 The Marl Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/osfiber_asm_arm.S
+++ b/src/osfiber_asm_arm.S
@@ -1,4 +1,4 @@
-// Copyright 2019 Google LLC
+// Copyright 2019 The Marl Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/osfiber_asm_arm.h
+++ b/src/osfiber_asm_arm.h
@@ -1,4 +1,4 @@
-// Copyright 2019 Google LLC
+// Copyright 2019 The Marl Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/osfiber_asm_x64.S
+++ b/src/osfiber_asm_x64.S
@@ -1,4 +1,4 @@
-// Copyright 2019 Google LLC
+// Copyright 2019 The Marl Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/osfiber_asm_x64.h
+++ b/src/osfiber_asm_x64.h
@@ -1,4 +1,4 @@
-// Copyright 2019 Google LLC
+// Copyright 2019 The Marl Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/osfiber_asm_x86.S
+++ b/src/osfiber_asm_x86.S
@@ -1,4 +1,4 @@
-// Copyright 2019 Google LLC
+// Copyright 2019 The Marl Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/osfiber_asm_x86.h
+++ b/src/osfiber_asm_x86.h
@@ -1,4 +1,4 @@
-// Copyright 2019 Google LLC
+// Copyright 2019 The Marl Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/osfiber_test.cpp
+++ b/src/osfiber_test.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019 Google LLC
+// Copyright 2019 The Marl Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/osfiber_ucontext.h
+++ b/src/osfiber_ucontext.h
@@ -1,4 +1,4 @@
-// Copyright 2019 Google LLC
+// Copyright 2019 The Marl Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/osfiber_windows.h
+++ b/src/osfiber_windows.h
@@ -1,4 +1,4 @@
-// Copyright 2019 Google LLC
+// Copyright 2019 The Marl Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/osfiber_x64.c
+++ b/src/osfiber_x64.c
@@ -1,4 +1,4 @@
-// Copyright 2019 Google LLC
+// Copyright 2019 The Marl Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/osfiber_x86.c
+++ b/src/osfiber_x86.c
@@ -1,4 +1,4 @@
-// Copyright 2019 Google LLC
+// Copyright 2019 The Marl Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/pool_test.cpp
+++ b/src/pool_test.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019 Google LLC
+// Copyright 2019 The Marl Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/scheduler.cpp
+++ b/src/scheduler.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019 Google LLC
+// Copyright 2019 The Marl Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/scheduler_test.cpp
+++ b/src/scheduler_test.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019 Google LLC
+// Copyright 2019 The Marl Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019 Google LLC
+// Copyright 2019 The Marl Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/ticket_test.cpp
+++ b/src/ticket_test.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019 Google LLC
+// Copyright 2019 The Marl Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/trace.cpp
+++ b/src/trace.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019 Google LLC
+// Copyright 2019 The Marl Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/waitgroup_test.cpp
+++ b/src/waitgroup_test.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019 Google LLC
+// Copyright 2019 The Marl Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
Lets external contributors have a single file to put their names (if they so wish).