### PR TITLE
CMake: Ensure MARL_BUILD_TESTS works

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -5,3 +5,4 @@
 # of contributors, see the revision history in source control.
 Google LLC
 Shawn Anastasio <shawn@anastas.io>
+A. Wilcox <awilfox@adelielinux.org>

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,7 +83,7 @@ set_target_properties(marl PROPERTIES
 )
 target_link_libraries(marl "${MARL_OS_LIBS}")
 
-if(BUILD_TESTS)
+if(MARL_BUILD_TESTS)
     file(GLOB MARL_TEST_LIST
         ${MARL_SRC_DIR}/*_test.cpp
         ${GOOGLETEST_DIR}/googletest/src/gtest-all.cc
@@ -103,7 +103,7 @@ if(BUILD_TESTS)
         FOLDER "Tests"
     )
     target_link_libraries(marl-unittests marl "${MARL_OS_LIBS}")
-endif(BUILD_TESTS)
+endif(MARL_BUILD_TESTS)
 
 if(MARL_BUILD_EXAMPLES)
     function(BUILD_EXAMPLE name)


### PR DESCRIPTION
The conditional for building tests was written as simply "BUILD_TESTS".
This commit changes it to use "MARL_BUILD_TESTS".

With this commit, my POWER9 in Big Endian mode can build, run, and pass
the Marl test suite.