### PR TITLE
examples/primes.cpp: Add missing header including

### DIFF
--- a/examples/primes.cpp
+++ b/examples/primes.cpp
@@ -20,6 +20,8 @@
 #include "marl/thread.h"
 #include "marl/ticket.h"
 
+#include <math.h>
+
 // searchMax defines the upper limit on primes to find.
 constexpr int searchMax = 10000000;
 


### PR DESCRIPTION
`sqrt` needs `math.h`.