### PR TITLE
CMake: Fix configuration file installation path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -139,12 +139,6 @@ target_link_libraries(marl "${MARL_OS_LIBS}")
 if(MARL_INSTALL)
     include(GNUInstallDirs)
 
-    if(UNIX)
-        set(CMAKE_INSTALL_CMAKEDIR "${CMAKE_INSTALL_LIBDIR}/cmake" CACHE STRING "")
-    else(UNIX)
-        set(CMAKE_INSTALL_CMAKEDIR "cmake" CACHE STRING "")
-    endif(UNIX)
-
     install(DIRECTORY ${MARL_INCLUDE_DIR}/marl
         DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
         USE_SOURCE_PERMISSIONS
@@ -161,7 +155,7 @@ if(MARL_INSTALL)
     install(EXPORT marl-targets
         FILE marl-config.cmake
         NAMESPACE marl::
-        DESTINATION ${CMAKE_INSTALL_CMAKEDIR}/marl
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/marl
     )
 endif(MARL_INSTALL)
 


### PR DESCRIPTION
Hi! I made a mistake in https://github.com/google/marl/pull/21 .
According to https://cmake.org/cmake/help/latest/command/find_package.html:
```
CMake constructs a set of possible installation prefixes for the package. Under each prefix several directories are searched for a configuration file. The tables below show the directories searched. Each entry is meant for installation trees following Windows (W), UNIX (U), or Apple (A) conventions:

<prefix>/                                                       (W)
<prefix>/(cmake|CMake)/                                         (W)
<prefix>/<name>*/                                               (W)
<prefix>/<name>*/(cmake|CMake)/                                 (W)
<prefix>/<name>*/(lib/<arch>|lib*|share)/cmake/<name>*/         (W/U)
<prefix>/<name>*/(lib/<arch>|lib*|share)/<name>*/               (W/U)
<prefix>/<name>*/(lib/<arch>|lib*|share)/<name>*/(cmake|CMake)/ (W/U)
```
So installing CMake configuration files into `cmake/marl` will not work out-of-box. Instead, we should install them into `cmake` or `lib/cmake/marl`.
