### PR TITLE
Kokoro: Split build rules by build system

### DIFF
--- a/kokoro/linux/bazel/presubmit.cfg
+++ b/kokoro/linux/bazel/presubmit.cfg
@@ -1,4 +1,9 @@
 # Format: //devtools/kokoro/config/proto/build.proto
 
 # Location of the continuous bash script in Git.
-build_file: "marl/kokoro/macos/presubmit.sh"
+build_file: "marl/kokoro/linux/presubmit.sh"
+
+env_vars {
+  key: "BUILD_SYSTEM"
+  value: "bazel"
+}

--- a/kokoro/linux/cmake/presubmit.cfg
+++ b/kokoro/linux/cmake/presubmit.cfg
@@ -1,0 +1,9 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+
+# Location of the continuous bash script in Git.
+build_file: "marl/kokoro/linux/presubmit.sh"
+
+env_vars {
+  key: "BUILD_SYSTEM"
+  value: "cmake"
+}

--- a/kokoro/macos/bazel/presubmit.cfg
+++ b/kokoro/macos/bazel/presubmit.cfg
@@ -1,0 +1,9 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+
+# Location of the continuous bash script in Git.
+build_file: "marl/kokoro/macos/presubmit.sh"
+
+env_vars {
+  key: "BUILD_SYSTEM"
+  value: "bazel"
+}

--- a/kokoro/macos/cmake/presubmit.cfg
+++ b/kokoro/macos/cmake/presubmit.cfg
@@ -1,4 +1,9 @@
 # Format: //devtools/kokoro/config/proto/build.proto
 
 # Location of the continuous bash script in Git.
-build_file: "marl/kokoro/windows/presubmit.bat"
+build_file: "marl/kokoro/macos/presubmit.sh"
+
+env_vars {
+  key: "BUILD_SYSTEM"
+  value: "cmake"
+}

--- a/kokoro/windows/bazel/presubmit.cfg
+++ b/kokoro/windows/bazel/presubmit.cfg
@@ -1,0 +1,9 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+
+# Location of the continuous bash script in Git.
+build_file: "marl/kokoro/windows/presubmit.bat"
+
+env_vars {
+  key: "BUILD_SYSTEM"
+  value: "bazel"
+}

--- a/kokoro/windows/cmake/presubmit.cfg
+++ b/kokoro/windows/cmake/presubmit.cfg
@@ -1,4 +1,9 @@
 # Format: //devtools/kokoro/config/proto/build.proto
 
 # Location of the continuous bash script in Git.
-build_file: "marl/kokoro/linux/presubmit.sh"
+build_file: "marl/kokoro/windows/presubmit.bat"
+
+env_vars {
+  key: "BUILD_SYSTEM"
+  value: "cmake"
+}


### PR DESCRIPTION
Sets the `BUILD_SYSTEM` env var which is currently unused - CMake will be temporarily used for both 'cmake' and 'bazel' tests.

Adding bazel rules will come in another change.

Bug: #31