### PR TITLE
aarch64: Fix saving/restoring register r29 on fiber switch

### DIFF
--- a/src/osfiber_asm_aarch64.S
+++ b/src/osfiber_asm_aarch64.S
@@ -44,6 +44,7 @@ MARL_ASM_SYMBOL(marl_fiber_swap):
     str x26, [x0, #MARL_REG_r26]
     str x27, [x0, #MARL_REG_r27]
     str x28, [x0, #MARL_REG_r28]
+    str x29, [x0, #MARL_REG_r29]
 
     str d8,  [x0, #MARL_REG_v8]
     str d9,  [x0, #MARL_REG_v9]
@@ -78,6 +79,7 @@ MARL_ASM_SYMBOL(marl_fiber_swap):
     ldr x26, [x7, #MARL_REG_r26]
     ldr x27, [x7, #MARL_REG_r27]
     ldr x28, [x7, #MARL_REG_r28]
+    ldr x29, [x7, #MARL_REG_r29]
 
     ldr d8,  [x7, #MARL_REG_v8]
     ldr d9,  [x7, #MARL_REG_v9]

--- a/src/osfiber_asm_aarch64.h
+++ b/src/osfiber_asm_aarch64.h
@@ -27,16 +27,17 @@
 #define MARL_REG_r26 0x60
 #define MARL_REG_r27 0x68
 #define MARL_REG_r28 0x70
-#define MARL_REG_v8 0x78
-#define MARL_REG_v9 0x80
-#define MARL_REG_v10 0x88
-#define MARL_REG_v11 0x90
-#define MARL_REG_v12 0x98
-#define MARL_REG_v13 0xa0
-#define MARL_REG_v14 0xa8
-#define MARL_REG_v15 0xb0
-#define MARL_REG_SP 0xb8
-#define MARL_REG_LR 0xc0
+#define MARL_REG_r29 0x78
+#define MARL_REG_v8 0x80
+#define MARL_REG_v9 0x88
+#define MARL_REG_v10 0x90
+#define MARL_REG_v11 0x98
+#define MARL_REG_v12 0xa0
+#define MARL_REG_v13 0xa8
+#define MARL_REG_v14 0xb0
+#define MARL_REG_v15 0xb8
+#define MARL_REG_SP 0xc0
+#define MARL_REG_LR 0xc8
 
 #if defined(__APPLE__)
 #define MARL_ASM_SYMBOL(x) _##x
@@ -71,6 +72,7 @@ struct marl_fiber_context {
   uintptr_t r26;
   uintptr_t r27;
   uintptr_t r28;
+  uintptr_t r29;
 
   uintptr_t v8;
   uintptr_t v9;
@@ -116,6 +118,8 @@ static_assert(offsetof(marl_fiber_context, r26) == MARL_REG_r26,
 static_assert(offsetof(marl_fiber_context, r27) == MARL_REG_r27,
               "Bad register offset");
 static_assert(offsetof(marl_fiber_context, r28) == MARL_REG_r28,
+              "Bad register offset");
+static_assert(offsetof(marl_fiber_context, r29) == MARL_REG_r29,
               "Bad register offset");
 static_assert(offsetof(marl_fiber_context, v8) == MARL_REG_v8,
               "Bad register offset");


### PR DESCRIPTION
AArch64 register r29 (x29) is designated as the frame pointer and the
standard calling convention states that "A subroutine invocation must
preserve the contents of the registers r19-r29 and SP." In other words
it must be callee-saved.

Reference:
http://infocenter.arm.com/help/topic/com.arm.doc.ihi0055b/IHI0055B_aapcs64.pdf

This was leading to program aborts in __stack_chk_fail(), which gets
called in the function epilogue when the cookie/canary value that gets
inserted onto the stack by the -fstack-protector option no longer
matches the value that was written at the start of the function. This
gets reported as a stack corruption, but in this case it was actually
the stack frame register pointing to a different stack, which is
unlikely to contain the cookie value at the same offset.

Google bug: b/140967243