### PR TITLE
Add marl::Event.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -172,6 +172,7 @@ if(MARL_BUILD_TESTS)
         ${MARL_SRC_DIR}/conditionvariable_test.cpp
         ${MARL_SRC_DIR}/containers_test.cpp
         ${MARL_SRC_DIR}/defer_test.cpp
+        ${MARL_SRC_DIR}/event_test.cpp
         ${MARL_SRC_DIR}/marl_test.cpp
         ${MARL_SRC_DIR}/marl_test.h
         ${MARL_SRC_DIR}/memory_test.cpp

--- a/include/marl/event.h
+++ b/include/marl/event.h
@@ -1,0 +1,130 @@
+// Copyright 2019 The Marl Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef marl_event_h
+#define marl_event_h
+
+#include "conditionvariable.h"
+#include "memory.h"
+
+namespace marl {
+
+// Event is a synchronization primitive used to block until a signal is raised.
+class Event {
+ public:
+  enum class Mode {
+    // The event signal will be automatically reset when a call to wait()
+    // returns.
+    // A single call to signal() will only unblock a single (possibly
+    // future) call to wait().
+    Auto,
+
+    // While the event is in the signaled state, any calls to wait() will
+    // unblock without automatically reseting the signaled state.
+    // The signaled state can be reset with a call to clear().
+    Manual
+  };
+
+  inline Event(Mode mode = Mode::Auto,
+               bool initialState = false,
+               Allocator* allocator = Allocator::Default);
+
+  // signal() signals the event, possibly unblocking a call to wait().
+  inline void signal() const;
+
+  // clear() clears the signaled state.
+  inline void clear() const;
+
+  // wait() blocks until the event is signaled.
+  // If the event was constructed with the Auto Mode, then only one
+  // call to wait() will unblock before returning, upon which the signalled
+  // state will be automatically cleared.
+  inline void wait() const;
+
+  // test() returns true if the event is signaled, otherwise false.
+  // If the event is signalled and was constructed with the Auto Mode
+  // then the signalled state will be automatically cleared upon returning.
+  inline bool test() const;
+
+  // isSignalled() returns true if the event is signaled, otherwise false.
+  // Unlike test() the signal is not automatically cleared when the event was
+  // constructed with the Auto Mode.
+  // Note: No lock is held after bool() returns, so the event state may
+  // immediately change after returning. Use with caution.
+  inline bool isSignalled() const;
+
+ private:
+  struct Data {
+    inline Data(Mode mode, bool initialState);
+    std::mutex mutex;
+    ConditionVariable cv;
+    const Mode mode;
+    bool signalled;
+  };
+  const std::shared_ptr<Data> shared;
+};
+
+Event::Data::Data(Mode mode, bool initialState)
+    : mode(mode), signalled(initialState) {}
+
+Event::Event(Mode mode /* = Mode::Auto */,
+             bool initialState /* = false */,
+             Allocator* allocator /* = Allocator::Default */)
+    : shared(allocator->make_shared<Data>(mode, initialState)) {}
+
+void Event::signal() const {
+  std::unique_lock<std::mutex> lock(shared->mutex);
+  if (shared->signalled) {
+    return;
+  }
+  shared->signalled = true;
+  if (shared->mode == Mode::Auto) {
+    shared->cv.notify_one();
+  } else {
+    shared->cv.notify_all();
+  }
+}
+
+void Event::clear() const {
+  std::unique_lock<std::mutex> lock(shared->mutex);
+  shared->signalled = false;
+}
+
+void Event::wait() const {
+  std::unique_lock<std::mutex> lock(shared->mutex);
+  shared->cv.wait(lock, [&] { return shared->signalled; });
+  if (shared->mode == Mode::Auto) {
+    shared->signalled = false;
+  }
+}
+
+bool Event::test() const {
+  std::unique_lock<std::mutex> lock(shared->mutex);
+  if (!shared->signalled) {
+    return false;
+  }
+  if (shared->mode == Mode::Auto) {
+    shared->signalled = false;
+  }
+  return true;
+}
+
+bool Event::isSignalled() const {
+  std::unique_lock<std::mutex> lock(shared->mutex);
+  return shared->signalled;
+}
+
+}  // namespace marl
+
+#endif  // marl_event_h

--- a/src/event_test.cpp
+++ b/src/event_test.cpp
@@ -1,0 +1,120 @@
+// Copyright 2019 The Marl Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "marl/event.h"
+#include "marl/waitgroup.h"
+
+#include "marl_test.h"
+
+TEST_P(WithBoundScheduler, EventIsSignalled) {
+  std::vector<marl::Event::Mode> modes = {marl::Event::Mode::Manual,
+                                          marl::Event::Mode::Auto};
+  for (auto mode : modes) {
+    auto event = marl::Event(mode);
+    ASSERT_EQ(event.isSignalled(), false);
+    event.signal();
+    ASSERT_EQ(event.isSignalled(), true);
+    ASSERT_EQ(event.isSignalled(), true);
+    event.clear();
+    ASSERT_EQ(event.isSignalled(), false);
+  }
+}
+
+TEST_P(WithBoundScheduler, EventAutoTest) {
+  auto event = marl::Event(marl::Event::Mode::Auto);
+  ASSERT_EQ(event.test(), false);
+  event.signal();
+  ASSERT_EQ(event.test(), true);
+  ASSERT_EQ(event.test(), false);
+}
+
+TEST_P(WithBoundScheduler, EventManualTest) {
+  auto event = marl::Event(marl::Event::Mode::Manual);
+  ASSERT_EQ(event.test(), false);
+  event.signal();
+  ASSERT_EQ(event.test(), true);
+  ASSERT_EQ(event.test(), true);
+}
+
+TEST_P(WithBoundScheduler, EventAutoWait) {
+  std::atomic<int> counter = {0};
+  auto event = marl::Event(marl::Event::Mode::Auto);
+  auto done = marl::Event(marl::Event::Mode::Auto);
+
+  for (int i = 0; i < 3; i++) {
+    marl::schedule([=, &counter] {
+      event.wait();
+      counter++;
+      done.signal();
+    });
+  }
+
+  ASSERT_EQ(counter.load(), 0);
+  event.signal();
+  done.wait();
+  ASSERT_EQ(counter.load(), 1);
+  event.signal();
+  done.wait();
+  ASSERT_EQ(counter.load(), 2);
+  event.signal();
+  done.wait();
+  ASSERT_EQ(counter.load(), 3);
+}
+
+TEST_P(WithBoundScheduler, EventManualWait) {
+  std::atomic<int> counter = {0};
+  auto event = marl::Event(marl::Event::Mode::Manual);
+  auto wg = marl::WaitGroup(3);
+  for (int i = 0; i < 3; i++) {
+    marl::schedule([=, &counter] {
+      event.wait();
+      counter++;
+      wg.done();
+    });
+  }
+  event.signal();
+  wg.wait();
+  ASSERT_EQ(counter.load(), 3);
+}
+
+TEST_P(WithBoundScheduler, EventSequence) {
+  std::vector<marl::Event::Mode> modes = {marl::Event::Mode::Manual,
+                                          marl::Event::Mode::Auto};
+  for (auto mode : modes) {
+    std::string sequence;
+    auto eventA = marl::Event(mode);
+    auto eventB = marl::Event(mode);
+    auto eventC = marl::Event(mode);
+    auto done = marl::Event(mode);
+    marl::schedule([=, &sequence] {
+      eventB.wait();
+      sequence += "B";
+      eventC.signal();
+    });
+    marl::schedule([=, &sequence] {
+      eventA.wait();
+      sequence += "A";
+      eventB.signal();
+    });
+    marl::schedule([=, &sequence] {
+      eventC.wait();
+      sequence += "C";
+      done.signal();
+    });
+    ASSERT_EQ(sequence, "");
+    eventA.signal();
+    done.wait();
+    ASSERT_EQ(sequence, "ABC");
+  }
+}


### PR DESCRIPTION
Event is a synchronization primitive used to block until a signal is raised.

Fixes: #46