### PR TITLE
Scheduler: Fix issues with fiber lists and timeouts.

### DIFF
--- a/src/event_test.cpp
+++ b/src/event_test.cpp
@@ -191,6 +191,27 @@ TEST_P(WithBoundScheduler, EventWaitUntilTimeTaken) {
   wg.wait();
 }
 
+// EventWaitStressTest spins up a whole lot of wait_fors(), unblocks them early,
+// and then let's all the workers go to idle before repeating.
+// This is testing to ensure that the scheduler handles timeouts correctly when
+// they are early-unblocked. Specifically, this is to test that fibers are
+// not double-placed into the idle or working lists.
+TEST_P(WithBoundScheduler, EventWaitStressTest) {
+  auto event = marl::Event(marl::Event::Mode::Manual);
+  for (int i = 0; i < 10; i++) {
+    auto wg = marl::WaitGroup(1000);
+    for (int j = 0; j < 1000; j++) {
+      marl::schedule([=] {
+        defer(wg.done());
+        event.wait_for(std::chrono::milliseconds(100));
+      });
+    }
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    event.signal();  // unblock
+    wg.wait();
+  }
+}
+
 TEST_P(WithBoundScheduler, EventAny) {
   for (int i = 0; i < 3; i++) {
     std::vector<marl::Event> events = {

--- a/src/scheduler.cpp
+++ b/src/scheduler.cpp
@@ -43,6 +43,14 @@ inline T take(std::queue<T>& queue) {
   return out;
 }
 
+template <typename T>
+inline T take(std::unordered_set<T>& set) {
+  auto it = set.begin();
+  auto out = std::move(*it);
+  set.erase(it);
+  return out;
+}
+
 inline void nop() {
 #if defined(_WIN32)
   __nop();
@@ -219,8 +227,7 @@ void Scheduler::Fiber::yield() {
   worker->yield(this, nullptr);
 }
 
-void Scheduler::Fiber::yield_until_sc(
-    const std::chrono::system_clock::time_point& timeout) {
+void Scheduler::Fiber::yield_until_sc(const TimePoint& timeout) {
   MARL_SCOPED_EVENT("YIELD_UNTIL");
   worker->yield(this, &timeout);
 }
@@ -244,6 +251,60 @@ Allocator::unique_ptr<Scheduler::Fiber>
 Scheduler::Fiber::createFromCurrentThread(Allocator* allocator, uint32_t id) {
   return allocator->make_unique<Fiber>(
       OSFiber::createFiberFromCurrentThread(allocator), id);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Scheduler::WaitingFibers
+////////////////////////////////////////////////////////////////////////////////
+Scheduler::WaitingFibers::operator bool() const {
+  return fibers.size() > 0;
+}
+
+Scheduler::Fiber* Scheduler::WaitingFibers::take(const TimePoint& timepoint) {
+  if (!*this) {
+    return nullptr;
+  }
+  auto it = timeouts.begin();
+  if (timepoint < it->timepoint) {
+    return nullptr;
+  }
+  auto fiber = it->fiber;
+  timeouts.erase(it);
+  auto deleted = fibers.erase(fiber) != 0;
+  (void)deleted;
+  MARL_ASSERT(deleted, "WaitingFibers::take() maps out of sync");
+  return fiber;
+}
+
+Scheduler::TimePoint Scheduler::WaitingFibers::next() const {
+  MARL_ASSERT(*this,
+              "WaitingFibers::next() called when there' no waiting fibers");
+  return timeouts.begin()->timepoint;
+}
+
+void Scheduler::WaitingFibers::add(const TimePoint& timepoint, Fiber* fiber) {
+  timeouts.emplace(Timeout{timepoint, fiber});
+  bool added = fibers.emplace(fiber, timepoint).second;
+  (void)added;
+  MARL_ASSERT(added, "WaitingFibers::add() fiber already waiting");
+}
+
+void Scheduler::WaitingFibers::erase(Fiber* fiber) {
+  auto it = fibers.find(fiber);
+  if (it != fibers.end()) {
+    auto timeout = it->second;
+    auto erased = timeouts.erase(Timeout{timeout, fiber}) != 0;
+    (void)erased;
+    MARL_ASSERT(erased, "WaitingFibers::erase() maps out of sync");
+    fibers.erase(it);
+  }
+}
+
+bool Scheduler::WaitingFibers::Timeout::operator<(const Timeout& o) const {
+  if (timepoint != o.timepoint) {
+    return timepoint < o.timepoint;
+  }
+  return fiber < o.fiber;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -312,7 +373,7 @@ void Scheduler::Worker::yield(
 
   std::unique_lock<std::mutex> lock(work.mutex);
   if (timeout != nullptr) {
-    work.waiting.emplace(*timeout, from);
+    work.waiting.add(*timeout, from);
   }
 
   // First wait until there's something else this worker can do.
@@ -343,6 +404,7 @@ bool Scheduler::Worker::tryLock() {
 void Scheduler::Worker::enqueue(Fiber* fiber) {
   std::unique_lock<std::mutex> lock(work.mutex);
   auto wasIdle = work.num == 0;
+  work.waiting.erase(fiber);
   work.fibers.push(std::move(fiber));
   work.num++;
   lock.unlock();
@@ -396,9 +458,8 @@ void Scheduler::Worker::run() {
                        Fiber::current()->id);
       {
         std::unique_lock<std::mutex> lock(work.mutex);
-        work.added.wait(lock, [this] {
-          return work.num > 0 || work.waiting.size() > 0 || shutdown;
-        });
+        work.added.wait(
+            lock, [this] { return work.num > 0 || work.waiting || shutdown; });
         while (!shutdown || work.num > 0 || numBlockedFibers() > 0U) {
           waitForWork(lock);
           runUntilIdle(lock);
@@ -432,9 +493,8 @@ _Requires_lock_held_(lock) void Scheduler::Worker::waitForWork(
     lock.lock();
   }
 
-  if (work.waiting.size() > 0) {
-    auto waiting = *work.waiting.begin();
-    work.added.wait_until(lock, waiting.first, [this] {
+  if (work.waiting) {
+    work.added.wait_until(lock, work.waiting.next(), [this] {
       return work.num > 0 || (shutdown && numBlockedFibers() == 0U);
     });
     enqueueFiberTimeouts();
@@ -447,13 +507,8 @@ _Requires_lock_held_(lock) void Scheduler::Worker::waitForWork(
 
 _Requires_lock_held_(lock) void Scheduler::Worker::enqueueFiberTimeouts() {
   auto now = std::chrono::system_clock::now();
-  while (work.waiting.size() > 0) {
-    auto it = work.waiting.begin();
-    if (it->first > now) {
-      break;
-    }
-    work.fibers.push(it->second);
-    work.waiting.erase(it);
+  while (auto fiber = work.waiting.take(now)) {
+    work.fibers.push(fiber);
     work.num++;
   }
 }
@@ -502,7 +557,11 @@ _Requires_lock_held_(lock) void Scheduler::Worker::runUntilIdle(
       work.num--;
       auto fiber = take(work.fibers);
       lock.unlock();
-      idleFibers.push(currentFiber);
+
+      auto added = idleFibers.emplace(currentFiber).second;
+      (void)added;
+      MARL_ASSERT(added, "fiber already idle");
+
       switchToFiber(fiber);
       lock.lock();
     }
@@ -534,6 +593,8 @@ Scheduler::Fiber* Scheduler::Worker::createWorkerFiber() {
 }
 
 void Scheduler::Worker::switchToFiber(Fiber* to) {
+  MARL_ASSERT(to == mainFiber.get() || idleFibers.count(to) == 0,
+              "switching to idle fiber");
   auto from = currentFiber;
   currentFiber = to;
   from->switchTo(to);


### PR DESCRIPTION
If a fiber is placed into the `WaitingFiberQueue` and is unblocked before the timeout, we can end up waking the fiber while it is waiting on another task (spurious wake up), or when the fiber is supposed to be idle.

The latter is rarer, but is more serious as it can cause the fiber to end up enqueued multiple times or placed into `idleFibers` multiple times. This breaks the internal state, and can cause more serious problems.

To fix this, the WaitingFiberQueue is replaced with a bidirectional `TimePoint` <-> `Fiber` map, and fibers are removed from this map when they are unblocked before timeout.

Added more tests to handle this case.