### PR TITLE
CMakeLists: Don't repeatedly include MARL_OS_LIBS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -199,7 +199,7 @@ if(MARL_BUILD_TESTS)
 
     marl_set_target_options(marl-unittests)
 
-    target_link_libraries(marl-unittests marl "${MARL_OS_LIBS}")
+    target_link_libraries(marl-unittests marl)
 endif(MARL_BUILD_TESTS)
 
 # examples
@@ -210,7 +210,7 @@ if(MARL_BUILD_EXAMPLES)
             FOLDER "Examples"
         )
         marl_set_target_options(${target})
-        target_link_libraries(${target} marl "${MARL_OS_LIBS}")
+        target_link_libraries(${target} marl)
     endfunction(build_example)
 
     build_example(fractal)


### PR DESCRIPTION
`target_link_libraries()` "Specify libraries or flags to use when linking a given target and/or its dependents."

Given that `target_link_libraries()` is called with `MARL_OS_LIBS` for the `marl` target, we don't need to include these libs for the tests and examples.

This completely contradicts what is observed in #60.