### PR TITLE
CMake: Make the marl target's include directory public

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -135,7 +135,7 @@ function(marl_set_target_options target)
         target_link_libraries(${target} "-fsanitize=thread")
     endif()
 
-    target_include_directories(${target} PRIVATE ${MARL_INCLUDE_DIR})
+    target_include_directories(${target} PUBLIC ${MARL_INCLUDE_DIR})
 endfunction(marl_set_target_options)
 
 ###########################################################

--- a/README.md
+++ b/README.md
@@ -55,12 +55,6 @@ This will define the `marl` library target, which you can pass to `target_link_l
 target_link_libraries(<target> marl) # replace <target> with the name of your project's target
 ```
 
-You will also want to add the `marl` public headers to your project's include search paths so you can `#include` the marl headers:
-
-```cmake
-target_include_directories($<target> PRIVATE "${MARL_DIR}/include") # replace <target> with the name of your project's target
-```
-
 You may also wish to specify your own paths to the third party libraries used by `marl`.
 You can do this by setting any of the following variables before the call to `add_subdirectory()`:
 


### PR DESCRIPTION
Avoids having to pull this in as an explicit include directory for projects that depend on marl.