### PR TITLE
Add benchmarks using google benchmark

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "third_party/googletest"]
 	path = third_party/googletest
 	url = https://github.com/google/googletest.git
+[submodule "third_party/benchmark"]
+	path = third_party/benchmark
+	url = https://github.com/google/benchmark.git

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -21,6 +21,7 @@ cc_library(
             "src/**/*.h",
         ],
         exclude = glob([
+            "src/**/*_bench.cpp",
             "src/**/*_test.cpp",
         ]),
     ) + select({

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,7 @@ endfunction()
 option_if_not_defined(MARL_WARNINGS_AS_ERRORS "Treat warnings as errors" OFF)
 option_if_not_defined(MARL_BUILD_EXAMPLES "Build example applications" OFF)
 option_if_not_defined(MARL_BUILD_TESTS "Build tests" OFF)
+option_if_not_defined(MARL_BUILD_BENCHMARKS "Build benchmarks" OFF)
 option_if_not_defined(MARL_ASAN "Build marl with address sanitizer" OFF)
 option_if_not_defined(MARL_MSAN "Build marl with memory sanitizer" OFF)
 option_if_not_defined(MARL_TSAN "Build marl with thread sanitizer" OFF)
@@ -48,17 +49,31 @@ set(MARL_SRC_DIR ${CMAKE_CURRENT_SOURCE_DIR}/src)
 set(MARL_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/include)
 set_if_not_defined(MARL_THIRD_PARTY_DIR ${CMAKE_CURRENT_SOURCE_DIR}/third_party)
 set_if_not_defined(MARL_GOOGLETEST_DIR ${MARL_THIRD_PARTY_DIR}/googletest)
+set_if_not_defined(MARL_BENCHMARK_DIR ${MARL_THIRD_PARTY_DIR}/benchmark)
 
 ###########################################################
 # Submodules
 ###########################################################
 if(MARL_BUILD_TESTS)
-    if(NOT EXISTS ${MARL_THIRD_PARTY_DIR}/googletest/.git)
+    if(NOT EXISTS ${MARL_GOOGLETEST_DIR}/.git)
         message(WARNING "third_party/googletest submodule missing.")
         message(WARNING "Run: `git submodule update --init` to build tests.")
         set(MARL_BUILD_TESTS OFF)
     endif()
 endif(MARL_BUILD_TESTS)
+
+if(MARL_BUILD_BENCHMARKS)
+    if(NOT EXISTS ${MARL_BENCHMARK_DIR}/.git)
+        message(WARNING "third_party/benchmark submodule missing.")
+        message(WARNING "Run: `git submodule update --init` to build benchmarks.")
+        set(MARL_BUILD_BENCHMARKS OFF)
+    endif()
+endif(MARL_BUILD_BENCHMARKS)
+
+if(MARL_BUILD_BENCHMARKS)
+    set(BENCHMARK_ENABLE_TESTING FALSE CACHE BOOL FALSE FORCE)
+    add_subdirectory(${MARL_BENCHMARK_DIR})
+endif(MARL_BUILD_BENCHMARKS)
 
 ###########################################################
 # File lists
@@ -212,6 +227,26 @@ if(MARL_BUILD_TESTS)
 
     target_link_libraries(marl-unittests marl)
 endif(MARL_BUILD_TESTS)
+
+# benchmarks
+if(MARL_BUILD_BENCHMARKS)
+    set(MARL_BENCHMARK_LIST
+        ${MARL_SRC_DIR}/blockingcall_bench.cpp
+        ${MARL_SRC_DIR}/defer_bench.cpp
+        ${MARL_SRC_DIR}/event_bench.cpp
+        ${MARL_SRC_DIR}/marl_bench.cpp
+        ${MARL_SRC_DIR}/non_marl_bench.cpp
+        ${MARL_SRC_DIR}/scheduler_bench.cpp
+        ${MARL_SRC_DIR}/ticket_bench.cpp
+        ${MARL_SRC_DIR}/waitgroup_bench.cpp
+    )
+
+    add_executable(marl-benchmarks ${MARL_BENCHMARK_LIST})
+
+    marl_set_target_options(marl-benchmarks)
+
+    target_link_libraries(marl-benchmarks benchmark::benchmark marl)
+endif(MARL_BUILD_BENCHMARKS)
 
 # examples
 if(MARL_BUILD_EXAMPLES)

--- a/src/blockingcall_bench.cpp
+++ b/src/blockingcall_bench.cpp
@@ -1,0 +1,24 @@
+// Copyright 2020 The Marl Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "marl/blockingcall.h"
+
+#include "benchmark/benchmark.h"
+
+static void BlockingCall(benchmark::State& state) {
+  for (auto _ : state) {
+    marl::blocking_call([] {});
+  }
+}
+BENCHMARK(BlockingCall);

--- a/src/defer_bench.cpp
+++ b/src/defer_bench.cpp
@@ -1,0 +1,25 @@
+// Copyright 2020 The Marl Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "marl/defer.h"
+
+#include "benchmark/benchmark.h"
+
+static void Defer(benchmark::State& state) {
+  int i = 0;
+  for (auto _ : state) {
+    defer(benchmark::DoNotOptimize(i++));
+  }
+}
+BENCHMARK(Defer);

--- a/src/event_bench.cpp
+++ b/src/event_bench.cpp
@@ -1,0 +1,38 @@
+// Copyright 2020 The Marl Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "marl_bench.h"
+
+#include "marl/event.h"
+
+#include "benchmark/benchmark.h"
+
+#include <vector>
+
+BENCHMARK_DEFINE_F(Schedule, Event)(benchmark::State& state) {
+  run(state, [&](int numTasks) {
+    for (auto _ : state) {
+      std::vector<marl::Event> events(numTasks + 1);
+      for (auto i = 0; i < numTasks; i++) {
+        marl::schedule([=] {
+          events[i].wait();
+          events[i + 1].signal();
+        });
+      }
+      events.front().signal();
+      events.back().wait();
+    }
+  });
+}
+BENCHMARK_REGISTER_F(Schedule, Event)->Apply(Schedule::args<512>);

--- a/src/marl_bench.cpp
+++ b/src/marl_bench.cpp
@@ -1,0 +1,27 @@
+// Copyright 2020 The Marl Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "marl_bench.h"
+
+BENCHMARK_MAIN();
+
+uint32_t Schedule::doSomeWork(uint32_t x) {
+  uint32_t q = x;
+  for (uint32_t i = 0; i < 100000; i++) {
+    x = (x << 4) | x;
+    x = x | 0x1020;
+    x = (x >> 2) & q;
+  }
+  return x;
+}

--- a/src/marl_bench.h
+++ b/src/marl_bench.h
@@ -1,0 +1,65 @@
+// Copyright 2020 The Marl Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "marl/scheduler.h"
+#include "marl/thread.h"
+
+#include "benchmark/benchmark.h"
+
+class Schedule : public benchmark::Fixture {
+ public:
+  void SetUp(const ::benchmark::State&) {}
+
+  void TearDown(const ::benchmark::State&) {}
+
+  // run() creates a scheduler, sets the number of worker threads from the
+  // benchmark arguments, calls f, then unbinds and destructs the scheduler.
+  // F must be a function of the signature: void(int numTasks)
+  template <typename F>
+  void run(const ::benchmark::State& state, F&& f) {
+    marl::Scheduler scheduler;
+    scheduler.setWorkerThreadCount(numThreads(state));
+    scheduler.bind();
+    f(numTasks(state));
+    scheduler.unbind();
+  }
+
+  // args() sets up the benchmark to run from [1 .. NumTasks] tasks (in 8^n
+  // steps) across 0 worker threads to numLogicalCPUs.
+  template <int NumTasks = 0x40000>
+  static void args(benchmark::internal::Benchmark* b) {
+    b->ArgNames({"tasks", "threads"});
+    for (unsigned int tasks = 1U; tasks <= NumTasks; tasks *= 8) {
+      for (unsigned int threads = 0U; threads <= marl::Thread::numLogicalCPUs();
+           ++threads) {
+        b->Args({tasks, threads});
+      }
+    }
+  }
+
+  // numThreads return the number of threads in the benchmark run from the
+  // state.
+  static int numThreads(const ::benchmark::State& state) {
+    return static_cast<int>(state.range(1));
+  }
+
+  // numTasks return the number of tasks in the benchmark run from the state.
+  static int numTasks(const ::benchmark::State& state) {
+    return static_cast<int>(state.range(0));
+  }
+
+  // doSomeWork() performs some made up bit-shitfy algorithm that's difficult
+  // for a compiler to optimize and produces consistent results.
+  static uint32_t doSomeWork(uint32_t x);
+};

--- a/src/non_marl_bench.cpp
+++ b/src/non_marl_bench.cpp
@@ -1,0 +1,167 @@
+// Copyright 2020 The Marl Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This file contains a number of benchmarks that do not use marl.
+// They exist to compare marl's performance against other simple scheduler
+// approaches.
+
+#include "marl_bench.h"
+
+#include "benchmark/benchmark.h"
+
+#include <mutex>
+#include <queue>
+#include <thread>
+
+namespace {
+
+// Event provides a basic wait-and-signal synchronization primitive.
+class Event {
+ public:
+  // wait blocks until the event is fired.
+  void wait() {
+    std::unique_lock<std::mutex> lock(mutex_);
+    cv_.wait(lock, [&] { return signalled_; });
+  }
+
+  // signal signals the Event, unblocking any calls to wait.
+  void signal() {
+    std::unique_lock<std::mutex> lock(mutex_);
+    signalled_ = true;
+    cv_.notify_all();
+  }
+
+ private:
+  std::condition_variable cv_;
+  std::mutex mutex_;
+  bool signalled_ = false;
+};
+
+}  // anonymous namespace
+
+// A simple multi-thread, single-queue task executor that shares a single mutex
+// across N threads. This implementation suffers from lock contention.
+static void SingleQueueTaskExecutor(benchmark::State& state) {
+  using Task = std::function<uint32_t(uint32_t)>;
+
+  auto const numTasks = Schedule::numTasks(state);
+  auto const numThreads = Schedule::numThreads(state);
+
+  for (auto _ : state) {
+    state.PauseTiming();
+
+    std::mutex mutex;
+    // Set everything up with the mutex locked to prevent the threads from
+    // performing work while the timing is paused.
+    mutex.lock();
+
+    // Set up the tasks.
+    std::queue<Task> tasks;
+    for (int i = 0; i < numTasks; i++) {
+      tasks.push(Schedule::doSomeWork);
+    }
+
+    auto taskRunner = [&] {
+      while (true) {
+        Task task;
+
+        // Take the next task.
+        // Note that this lock is likely to block while waiting for other
+        // threads.
+        mutex.lock();
+        if (tasks.size() > 0) {
+          task = tasks.front();
+          tasks.pop();
+        }
+        mutex.unlock();
+
+        if (task) {
+          task(123);
+        } else {
+          return;  // done.
+        }
+      }
+    };
+
+    // Set up the threads.
+    std::vector<std::thread> threads;
+    for (int i = 0; i < numThreads; i++) {
+      threads.emplace_back(std::thread(taskRunner));
+    }
+
+    state.ResumeTiming();
+    mutex.unlock();  // Go threads, go!
+
+    if (numThreads > 0) {
+      // Wait for all threads to finish.
+      for (auto& thread : threads) {
+        thread.join();
+      }
+    } else {
+      // Single-threaded test - just run the worker.
+      taskRunner();
+    }
+  }
+}
+BENCHMARK(SingleQueueTaskExecutor)->Apply(Schedule::args);
+
+// A simple multi-thread, multi-queue task executor that avoids lock contention.
+// Tasks queues are evenly balanced, and each should take an equal amount of
+// time to execute.
+static void MultiQueueTaskExecutor(benchmark::State& state) {
+  using Task = std::function<uint32_t(uint32_t)>;
+  using TaskQueue = std::vector<Task>;
+
+  auto const numTasks = Schedule::numTasks(state);
+  auto const numThreads = Schedule::numThreads(state);
+  auto const numQueues = std::max(numThreads, 1);
+
+  // Set up the tasks queues.
+  std::vector<TaskQueue> taskQueues(numQueues);
+  for (int i = 0; i < numTasks; i++) {
+    taskQueues[i % numQueues].emplace_back(Schedule::doSomeWork);
+  }
+
+  for (auto _ : state) {
+    if (numThreads > 0) {
+      state.PauseTiming();
+      Event start;
+
+      // Set up the threads.
+      std::vector<std::thread> threads;
+      for (int i = 0; i < numThreads; i++) {
+        threads.emplace_back(std::thread([&, i] {
+          start.wait();
+          for (auto& task : taskQueues[i]) {
+            task(123);
+          }
+        }));
+      }
+
+      state.ResumeTiming();
+      start.signal();
+
+      // Wait for all threads to finish.
+      for (auto& thread : threads) {
+        thread.join();
+      }
+    } else {
+      // Single-threaded test - just run the tasks.
+      for (auto& task : taskQueues[0]) {
+        task(123);
+      }
+    }
+  }
+}
+BENCHMARK(MultiQueueTaskExecutor)->Apply(Schedule::args);

--- a/src/scheduler_bench.cpp
+++ b/src/scheduler_bench.cpp
@@ -1,0 +1,48 @@
+// Copyright 2020 The Marl Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "marl_bench.h"
+
+#include "marl/waitgroup.h"
+
+#include "benchmark/benchmark.h"
+
+BENCHMARK_DEFINE_F(Schedule, Empty)(benchmark::State& state) {
+  run(state, [&](int numTasks) {
+    for (auto _ : state) {
+      for (auto i = 0; i < numTasks; i++) {
+        marl::schedule([] {});
+      }
+    }
+  });
+}
+BENCHMARK_REGISTER_F(Schedule, Empty)->Apply(Schedule::args);
+
+BENCHMARK_DEFINE_F(Schedule, SomeWork)
+(benchmark::State& state) {
+  run(state, [&](int numTasks) {
+    for (auto _ : state) {
+      marl::WaitGroup wg;
+      wg.add(numTasks);
+      for (auto i = 0; i < numTasks; i++) {
+        marl::schedule([=] {
+          benchmark::DoNotOptimize(doSomeWork(i));
+          wg.done();
+        });
+      }
+      wg.wait();
+    }
+  });
+}
+BENCHMARK_REGISTER_F(Schedule, SomeWork)->Apply(Schedule::args);

--- a/src/ticket_bench.cpp
+++ b/src/ticket_bench.cpp
@@ -1,0 +1,39 @@
+// Copyright 2020 The Marl Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "marl_bench.h"
+
+#include "marl/defer.h"
+#include "marl/scheduler.h"
+#include "marl/thread.h"
+#include "marl/ticket.h"
+
+#include "benchmark/benchmark.h"
+
+BENCHMARK_DEFINE_F(Schedule, Ticket)(benchmark::State& state) {
+  run(state, [&](int numTasks) {
+    for (auto _ : state) {
+      marl::Ticket::Queue queue;
+      for (int i = 0; i < numTasks; i++) {
+        auto ticket = queue.take();
+        marl::schedule([ticket] {
+          ticket.wait();
+          ticket.done();
+        });
+      }
+      queue.take().wait();
+    }
+  });
+}
+BENCHMARK_REGISTER_F(Schedule, Ticket)->Apply(Schedule::args<512>);

--- a/src/waitgroup_bench.cpp
+++ b/src/waitgroup_bench.cpp
@@ -1,0 +1,31 @@
+// Copyright 2020 The Marl Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "marl_bench.h"
+
+#include "marl/waitgroup.h"
+
+BENCHMARK_DEFINE_F(Schedule, WaitGroup)(benchmark::State& state) {
+  run(state, [&](int numTasks) {
+    for (auto _ : state) {
+      marl::WaitGroup wg;
+      wg.add(numTasks);
+      for (auto i = 0; i < numTasks; i++) {
+        marl::schedule([=] { wg.done(); });
+      }
+      wg.wait();
+    }
+  });
+}
+BENCHMARK_REGISTER_F(Schedule, WaitGroup)->Apply(Schedule::args);


### PR DESCRIPTION
Add new git submodule to `third_party/benchmark` which points to github.com/google/benchmark.

Add a new CMake build flag `MARL_BUILD_BENCHMARKS`, which when enabled builds the benchmarks which have the `_bench.cpp` suffix.

Spits out lots of numbers.
Will use these to do some OS performance comparisons.
May also use this to automatically detect performance regressions.