### PR TITLE
Use SAL annotations more aggressively in the scheduler

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,2 +1,10 @@
 # http://clang.llvm.org/docs/ClangFormatStyleOptions.html
 BasedOnStyle: Chromium
+
+---
+Language:        Cpp
+StatementMacros:
+ - _Acquires_lock_
+ - _Releases_lock_
+ - _Requires_lock_held_
+ - _When_

--- a/include/marl/sal.h
+++ b/include/marl/sal.h
@@ -19,12 +19,24 @@
 #ifndef marl_sal_h
 #define marl_sal_h
 
-#ifndef _Requires_lock_held_
-#define _Requires_lock_held_(x)
+#ifndef _Acquires_lock_
+#define _Acquires_lock_(...)
 #endif
 
-#ifndef _Requires_lock_not_held_
-#define _Requires_lock_not_held_(x)
+#ifndef _Guarded_by_
+#define _Guarded_by_(...)
+#endif
+
+#ifndef _Releases_lock_
+#define _Releases_lock_(...)
+#endif
+
+#ifndef _Requires_lock_held_
+#define _Requires_lock_held_(...)
+#endif
+
+#ifndef _When_
+#define _When_(...)
 #endif
 
 #endif  // marl_sal_h


### PR DESCRIPTION
These changes should be no-op, but keeps MSVC's SAL analyzer happy.