### PR TITLE
Core: Rework fiber scheduling to fix broken behavior.

### DIFF
--- a/include/marl/scheduler.h
+++ b/include/marl/scheduler.h
@@ -50,6 +50,7 @@ class Scheduler {
 
  public:
   using TimePoint = std::chrono::system_clock::time_point;
+  using Predicate = std::function<bool()>;
 
   Scheduler(Allocator* allocator = Allocator::Default);
   ~Scheduler();
@@ -98,25 +99,49 @@ class Scheduler {
   // thread that previously executed it.
   class Fiber {
    public:
+    using Lock = std::unique_lock<std::mutex>;
+
     // current() returns the currently executing fiber, or nullptr if called
     // without a bound scheduler.
     static Fiber* current();
 
-    // yield() suspends execution of this Fiber, allowing the thread to work
-    // on other tasks.
-    // yield() must only be called on the currently executing fiber.
-    void yield();
+    // wait() suspends execution of this Fiber until the Fiber is woken up with
+    // a call to notify() and the predicate pred returns true.
+    // If the predicate pred does not return true when notify() is called, then
+    // the Fiber is automatically re-suspended, and will need to be woken with
+    // another call to notify().
+    // While the Fiber is suspended, the scheduler thread may continue executing
+    // other tasks.
+    // lock must be locked before calling, and is unlocked by wait() just before
+    // the Fiber is suspended, and re-locked before the fiber is resumed. lock
+    // will be locked before wait() returns.
+    // pred will be always be called with the lock held.
+    // wait() must only be called on the currently executing fiber.
+    void wait(Lock& lock, const Predicate& pred);
 
-    // yield_until() suspends execution of this Fiber, allowing the thread to
-    // work on other tasks. yield_until() may automatically resume sometime
-    // after timeout.
-    // yield_until() must only be called on the currently executing fiber.
+    // wait() suspends execution of this Fiber until the Fiber is woken up with
+    // a call to notify() and the predicate pred returns true, or sometime after
+    // the timeout is reached.
+    // If the predicate pred does not return true when notify() is called, then
+    // the Fiber is automatically re-suspended, and will need to be woken with
+    // another call to notify() or will be woken sometime after the timeout is
+    // reached.
+    // While the Fiber is suspended, the scheduler thread may continue executing
+    // other tasks.
+    // lock must be locked before calling, and is unlocked by wait() just before
+    // the Fiber is suspended, and re-locked before the fiber is resumed. lock
+    // will be locked before wait() returns.
+    // pred will be always be called with the lock held.
+    // wait() must only be called on the currently executing fiber.
     template <typename Clock, typename Duration>
-    inline void yield_until(
-        const std::chrono::time_point<Clock, Duration>& timeout);
+    inline bool wait(Lock& lock,
+                     const std::chrono::time_point<Clock, Duration>& timeout,
+                     const Predicate& pred);
 
-    // schedule() reschedules the suspended Fiber for execution.
-    void schedule();
+    // notify() reschedules the suspended Fiber for execution.
+    // notify() is usually only called when the predicate for one or more wait()
+    // calls will likely return true.
+    void notify();
 
     // id is the thread-unique identifier of the Fiber.
     uint32_t const id;
@@ -125,9 +150,28 @@ class Scheduler {
     friend class Allocator;
     friend class Scheduler;
 
-    Fiber(Allocator::unique_ptr<OSFiber>&&, uint32_t id);
+    enum class State {
+      // Idle: the Fiber is currently unused, and sits in Worker::idleFibers,
+      // ready to be recycled.
+      Idle,
 
-    void yield_until_sc(const TimePoint& timeout);
+      // Yielded: the Fiber is currently blocked on a wait() call with no
+      // timeout.
+      Yielded,
+
+      // Waiting: the Fiber is currently blocked on a wait() call with a
+      // timeout. The fiber is stilling in the Worker::Work::waiting queue.
+      Waiting,
+
+      // Queued: the Fiber is currently queued for execution in the
+      // Worker::Work::fibers queue.
+      Queued,
+
+      // Running: the Fiber is currently executing.
+      Running,
+    };
+
+    Fiber(Allocator::unique_ptr<OSFiber>&&, uint32_t id);
 
     // switchTo() switches execution to the given fiber.
     // switchTo() must only be called on the currently executing fiber.
@@ -147,8 +191,13 @@ class Scheduler {
         Allocator* allocator,
         uint32_t id);
 
+    // toString() returns a string representation of the given State.
+    // Used for debugging.
+    static const char* toString(State state);
+
     Allocator::unique_ptr<OSFiber> const impl;
     Worker* const worker;
+    State state = State::Running;  // Guarded by Worker's work.mutex.
   };
 
  private:
@@ -177,6 +226,9 @@ class Scheduler {
 
     // erase() removes the fiber from the waiting list.
     inline void erase(Fiber* fiber);
+
+    // contains() returns true if fiber is waiting.
+    inline bool contains(Fiber* fiber) const;
 
    private:
     struct Timeout {
@@ -216,11 +268,18 @@ class Scheduler {
     // tasks have fully finished.
     void stop();
 
-    // yield() suspends execution of the current task, and looks for other
-    // tasks to start or continue execution.
-    // If timeout is not nullptr, yield may automatically resume the current
-    // task sometime after timeout.
-    void yield(Fiber* fiber, const TimePoint* timeout);
+    // wait() suspends execution of the current task until the predicate pred
+    // returns true.
+    // See Fiber::wait() for more information.
+    bool wait(Fiber::Lock& lock,
+              const TimePoint* timeout,
+              const Predicate& pred);
+
+    // suspend() suspends the currenetly executing Fiber until the fiber is
+    // woken with a call to enqueue(Fiber*), or automatically sometime after the
+    // optional timeout.
+    _Requires_lock_held_(work.mutex)
+    void suspend(const TimePoint* timeout);
 
     // enqueue(Fiber*) enqueues resuming of a suspended fiber.
     void enqueue(Fiber* fiber);
@@ -291,6 +350,14 @@ class Scheduler {
     // waiting.
     _Requires_lock_held_(work.mutex)
     void enqueueFiberTimeouts();
+
+    _Requires_lock_held_(work.mutex)
+    inline void changeFiberState(Fiber* fiber,
+                                 Fiber::State from,
+                                 Fiber::State to) const;
+
+    _Requires_lock_held_(work.mutex)
+    inline void setFiberState(Fiber* fiber, Fiber::State to) const;
 
     // numBlockedFibers() returns the number of fibers currently blocked and
     // held externally.
@@ -370,11 +437,14 @@ class Scheduler {
 };
 
 template <typename Clock, typename Duration>
-void Scheduler::Fiber::yield_until(
-    const std::chrono::time_point<Clock, Duration>& timeout) {
+bool Scheduler::Fiber::wait(
+    Lock& lock,
+    const std::chrono::time_point<Clock, Duration>& timeout,
+    const Predicate& pred) {
   using ToDuration = typename TimePoint::duration;
   using ToClock = typename TimePoint::clock;
-  yield_until_sc(std::chrono::time_point_cast<ToDuration, ToClock>(timeout));
+  auto tp = std::chrono::time_point_cast<ToDuration, ToClock>(timeout);
+  return worker->wait(lock, &tp, pred);
 }
 
 Scheduler::Worker* Scheduler::Worker::getCurrent() {

--- a/src/event_test.cpp
+++ b/src/event_test.cpp
@@ -191,19 +191,20 @@ TEST_P(WithBoundScheduler, EventWaitUntilTimeTaken) {
   wg.wait();
 }
 
-// EventWaitStressTest spins up a whole lot of wait_fors(), unblocks them early,
-// and then let's all the workers go to idle before repeating.
+// EventWaitStressTest spins up a whole lot of wait_fors(), unblocking some
+// with timeouts and some with an event signal, and then let's all the workers
+// go to idle before repeating.
 // This is testing to ensure that the scheduler handles timeouts correctly when
 // they are early-unblocked. Specifically, this is to test that fibers are
 // not double-placed into the idle or working lists.
 TEST_P(WithBoundScheduler, EventWaitStressTest) {
   auto event = marl::Event(marl::Event::Mode::Manual);
   for (int i = 0; i < 10; i++) {
-    auto wg = marl::WaitGroup(1000);
-    for (int j = 0; j < 1000; j++) {
+    auto wg = marl::WaitGroup(100);
+    for (int j = 0; j < 100; j++) {
       marl::schedule([=] {
         defer(wg.done());
-        event.wait_for(std::chrono::milliseconds(100));
+        event.wait_for(std::chrono::milliseconds(j));
       });
     }
     std::this_thread::sleep_for(std::chrono::milliseconds(50));

--- a/src/scheduler.cpp
+++ b/src/scheduler.cpp
@@ -27,13 +27,37 @@
 // Enable to trace scheduler events.
 #define ENABLE_TRACE_EVENTS 0
 
+// Enable to print verbose debug logging.
+#define ENABLE_DEBUG_LOGGING 0
+
 #if ENABLE_TRACE_EVENTS
 #define TRACE(...) MARL_SCOPED_EVENT(__VA_ARGS__)
 #else
 #define TRACE(...)
 #endif
 
+#if ENABLE_DEBUG_LOGGING
+#define DBG_LOG(msg, ...) \
+  printf("%.3x " msg "\n", (int)threadID() & 0xfff, __VA_ARGS__)
+#else
+#define DBG_LOG(msg, ...)
+#endif
+
+#define ASSERT_FIBER_STATE(FIBER, STATE)                                   \
+  MARL_ASSERT(FIBER->state == STATE,                                       \
+              "fiber %d was in state %s, but expected %s", (int)FIBER->id, \
+              Fiber::toString(FIBER->state), Fiber::toString(STATE))
+
 namespace {
+
+#if ENABLE_DEBUG_LOGGING
+// threadID() returns a uint64_t representing the currently executing thread.
+// threadID() is only intended to be used for debugging purposes.
+inline uint64_t threadID() {
+  auto id = std::this_thread::get_id();
+  return std::hash<std::thread::id>()(id);
+}
+#endif
 
 template <typename T>
 inline T take(std::queue<T>& queue) {
@@ -77,7 +101,7 @@ void Scheduler::bind() {
   {
     std::unique_lock<std::mutex> lock(singleThreadedWorkerMutex);
     auto worker =
-        allocator->make_unique<Worker>(this, Worker::Mode::SingleThreaded, 0);
+        allocator->make_unique<Worker>(this, Worker::Mode::SingleThreaded, -1);
     worker->start();
     auto tid = std::this_thread::get_id();
     singleThreadedWorkers.emplace(tid, std::move(worker));
@@ -217,18 +241,12 @@ Scheduler::Fiber* Scheduler::Fiber::current() {
   return worker != nullptr ? worker->getCurrentFiber() : nullptr;
 }
 
-void Scheduler::Fiber::schedule() {
+void Scheduler::Fiber::notify() {
   worker->enqueue(this);
 }
 
-void Scheduler::Fiber::yield() {
-  MARL_SCOPED_EVENT("YIELD");
-  worker->yield(this, nullptr);
-}
-
-void Scheduler::Fiber::yield_until_sc(const TimePoint& timeout) {
-  MARL_SCOPED_EVENT("YIELD_UNTIL");
-  worker->yield(this, &timeout);
+void Scheduler::Fiber::wait(Lock& lock, const Predicate& pred) {
+  worker->wait(lock, nullptr, pred);
 }
 
 void Scheduler::Fiber::switchTo(Fiber* to) {
@@ -250,6 +268,23 @@ Allocator::unique_ptr<Scheduler::Fiber>
 Scheduler::Fiber::createFromCurrentThread(Allocator* allocator, uint32_t id) {
   return allocator->make_unique<Fiber>(
       OSFiber::createFiberFromCurrentThread(allocator), id);
+}
+
+const char* Scheduler::Fiber::toString(State state) {
+  switch (state) {
+    case State::Idle:
+      return "Idle";
+    case State::Yielded:
+      return "Yielded";
+    case State::Queued:
+      return "Queued";
+    case State::Running:
+      return "Running";
+    case State::Waiting:
+      return "Waiting";
+  }
+  MARL_ASSERT(false, "bad fiber state");
+  return "<unknown>";
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -297,6 +332,10 @@ void Scheduler::WaitingFibers::erase(Fiber* fiber) {
     MARL_ASSERT(erased, "WaitingFibers::erase() maps out of sync");
     fibers.erase(it);
   }
+}
+
+bool Scheduler::WaitingFibers::contains(Fiber* fiber) const {
+  return fibers.count(fiber) != 0;
 }
 
 bool Scheduler::WaitingFibers::Timeout::operator<(const Timeout& o) const {
@@ -362,17 +401,48 @@ void Scheduler::Worker::stop() {
   }
 }
 
-void Scheduler::Worker::yield(
-    Fiber* from,
+bool Scheduler::Worker::wait(Fiber::Lock& waitLock,
+                             const TimePoint* timeout,
+                             const Predicate& pred) {
+  DBG_LOG("%d: WAIT(%d)", (int)id, (int)currentFiber->id);
+  while (!pred()) {
+    // Lock the work mutex to call suspend().
+    work.mutex.lock();
+
+    // Unlock the wait mutex with the work mutex lock held.
+    // Order is important here as we need to ensure that the fiber is not
+    // enqueued (via Fiber::notify()) between the waitLock.unlock() and fiber
+    // switch, otherwise the Fiber::notify() call may be ignored and the fiber
+    // is never woken.
+    waitLock.unlock();
+
+    // suspend the fiber.
+    suspend(timeout);
+
+    // Fiber resumed. We don't need the work mutex locked any more.
+    work.mutex.unlock();
+
+    // Check timeout.
+    if (timeout != nullptr && std::chrono::system_clock::now() >= *timeout) {
+      return false;
+    }
+
+    // Spurious wake up. Re-lock, spin again.
+    waitLock.lock();
+  }
+  return true;
+}
+
+void Scheduler::Worker::suspend(
     const std::chrono::system_clock::time_point* timeout) {
-  MARL_ASSERT(currentFiber == from,
-              "Attempting to call yield from a non-current fiber");
-
   // Current fiber is yielding as it is blocked.
-
-  std::unique_lock<std::mutex> lock(work.mutex);
   if (timeout != nullptr) {
-    work.waiting.add(*timeout, from);
+    changeFiberState(currentFiber, Fiber::State::Running,
+                     Fiber::State::Waiting);
+    work.waiting.add(*timeout, currentFiber);
+  } else {
+    changeFiberState(currentFiber, Fiber::State::Running,
+                     Fiber::State::Yielded);
   }
 
   // First wait until there's something else this worker can do.
@@ -382,18 +452,26 @@ void Scheduler::Worker::yield(
     // There's another fiber that has become unblocked, resume that.
     work.num--;
     auto to = take(work.fibers);
-    lock.unlock();
+    ASSERT_FIBER_STATE(to, Fiber::State::Queued);
+    work.mutex.unlock();
     switchToFiber(to);
+    work.mutex.lock();
   } else if (idleFibers.size() > 0) {
     // There's an old fiber we can reuse, resume that.
     auto to = take(idleFibers);
-    lock.unlock();
+    ASSERT_FIBER_STATE(to, Fiber::State::Idle);
+    work.mutex.unlock();
     switchToFiber(to);
+    work.mutex.lock();
   } else {
-    // Tasks to process and no existing fibers to resume. Spawn a new fiber.
-    lock.unlock();
+    // Tasks to process and no existing fibers to resume.
+    // Spawn a new fiber.
+    work.mutex.unlock();
     switchToFiber(createWorkerFiber());
+    work.mutex.lock();
   }
+
+  setFiberState(currentFiber, Fiber::State::Running);
 }
 
 _When_(return == true, _Acquires_lock_(work.mutex))
@@ -403,11 +481,27 @@ bool Scheduler::Worker::tryLock() {
 
 void Scheduler::Worker::enqueue(Fiber* fiber) {
   std::unique_lock<std::mutex> lock(work.mutex);
-  auto wasIdle = work.num == 0;
-  work.waiting.erase(fiber);
+  DBG_LOG("%d: ENQUEUE(%d %s)", (int)id, (int)fiber->id,
+          Fiber::toString(fiber->state));
+  switch (fiber->state) {
+    case Fiber::State::Running:
+    case Fiber::State::Queued:
+      return;  // Nothing to do here - task is already queued or running.
+    case Fiber::State::Waiting:
+      work.waiting.erase(fiber);
+      break;
+    case Fiber::State::Idle:
+    case Fiber::State::Yielded:
+      break;
+  }
+  bool wasIdle = work.num == 0;
   work.fibers.push(std::move(fiber));
+  MARL_ASSERT(!work.waiting.contains(fiber),
+              "fiber is unexpectedly in the waiting list");
+  setFiberState(fiber, Fiber::State::Queued);
   work.num++;
   lock.unlock();
+
   if (wasIdle) {
     work.added.notify_one();
   }
@@ -473,6 +567,7 @@ void Scheduler::Worker::run() {
       break;
     }
     case Mode::SingleThreaded:
+      ASSERT_FIBER_STATE(currentFiber, Fiber::State::Running);
       while (!shutdown) {
         flush();
         idleFibers.emplace(currentFiber);
@@ -516,9 +611,29 @@ _Requires_lock_held_(work.mutex)
 void Scheduler::Worker::enqueueFiberTimeouts() {
   auto now = std::chrono::system_clock::now();
   while (auto fiber = work.waiting.take(now)) {
+    changeFiberState(fiber, Fiber::State::Waiting, Fiber::State::Queued);
+    DBG_LOG("%d: TIMEOUT(%d)", (int)id, (int)fiber->id);
     work.fibers.push(fiber);
     work.num++;
   }
+}
+
+_Requires_lock_held_(work.mutex)
+void Scheduler::Worker::changeFiberState(Fiber* fiber,
+                                         Fiber::State from,
+                                         Fiber::State to) const {
+  (void)from;  // Unusued parameter when ENABLE_DEBUG_LOGGING is disabled.
+  DBG_LOG("%d: CHANGE_FIBER_STATE(%d %s -> %s)", (int)id, (int)fiber->id,
+          Fiber::toString(from), Fiber::toString(to));
+  ASSERT_FIBER_STATE(fiber, from);
+  fiber->state = to;
+}
+
+_Requires_lock_held_(work.mutex)
+void Scheduler::Worker::setFiberState(Fiber* fiber, Fiber::State to) const {
+  DBG_LOG("%d: SET_FIBER_STATE(%d %s -> %s)", (int)id, (int)fiber->id,
+          Fiber::toString(fiber->state), Fiber::toString(to));
+  fiber->state = to;
 }
 
 void Scheduler::Worker::spinForWork() {
@@ -554,6 +669,7 @@ void Scheduler::Worker::spinForWork() {
 
 _Requires_lock_held_(work.mutex)
 void Scheduler::Worker::runUntilIdle() {
+  ASSERT_FIBER_STATE(currentFiber, Fiber::State::Running);
   MARL_ASSERT(work.num == work.fibers.size() + work.tasks.size(),
               "work.num out of sync");
   while (work.fibers.size() > 0 || work.tasks.size() > 0) {
@@ -564,14 +680,22 @@ void Scheduler::Worker::runUntilIdle() {
     while (work.fibers.size() > 0) {
       work.num--;
       auto fiber = take(work.fibers);
+      // Sanity checks,
+      MARL_ASSERT(idleFibers.count(fiber) == 0, "dequeued fiber is idle");
+      MARL_ASSERT(fiber != currentFiber, "dequeued fiber is currently running");
+      ASSERT_FIBER_STATE(fiber, Fiber::State::Queued);
+
+      changeFiberState(currentFiber, Fiber::State::Running, Fiber::State::Idle);
       work.mutex.unlock();
+      {  // unlocked
+        auto added = idleFibers.emplace(currentFiber).second;
+        (void)added;
+        MARL_ASSERT(added, "fiber already idle");
 
-      auto added = idleFibers.emplace(currentFiber).second;
-      (void)added;
-      MARL_ASSERT(added, "fiber already idle");
-
-      switchToFiber(fiber);
+        switchToFiber(fiber);
+      }
       work.mutex.lock();
+      changeFiberState(currentFiber, Fiber::State::Idle, Fiber::State::Running);
     }
 
     if (work.tasks.size() > 0) {
@@ -593,6 +717,7 @@ void Scheduler::Worker::runUntilIdle() {
 
 Scheduler::Fiber* Scheduler::Worker::createWorkerFiber() {
   auto fiberId = static_cast<uint32_t>(workerFibers.size() + 1);
+  DBG_LOG("%d: CREATE(%d)", (int)id, (int)fiberId);
   auto fiber = Fiber::create(scheduler->allocator, fiberId, FiberStackSize,
                              [&] { run(); });
   auto ptr = fiber.get();
@@ -601,6 +726,7 @@ Scheduler::Fiber* Scheduler::Worker::createWorkerFiber() {
 }
 
 void Scheduler::Worker::switchToFiber(Fiber* to) {
+  DBG_LOG("%d: SWITCH(%d -> %d)", (int)id, (int)currentFiber->id, (int)to->id);
   MARL_ASSERT(to == mainFiber.get() || idleFibers.count(to) == 0,
               "switching to idle fiber");
   auto from = currentFiber;


### PR DESCRIPTION
Tasks waiting on a timeout could end up being repeatedly scheduled, leading to chaos. Fortunately, nothing aggressively used this functionality (although this may have caused extremely infrequent bugs in SwiftShader fences).

The problem was mostly in `marl::ConditionVariable`:
Between the fiber being placed on the `waiting` set and the call to `yield()`, `ConditionVariable::notify_`xxx`()` methods could be called, which would end up waking the fiber twice (one immediate, one with timeout).

This change tackles the problem in two ways:
1) The `marl::Scheduler::Fiber::wait` method has been changed to mirror `ConditionVariable::wait` signature - it takes a lock, predicate and optional timeout. This ensures the scheduler worker lock is held while fiber transitions into the suspended state, preventing a notify sneaking in before the fiber is suspended and getting ignored.
2) The scheduler now keeps much better track of the state of each fiber, and now simply ignores calls to notify() when it is already running or queued. I've also littered the code with sanity checks to try and catch any cases where the logic goes off the rails.

The new early outs may also have some performance gains - benchmarks will confirm.

Also tweaked the EventWaitStressTest so that the old bug is far more easily reproduced. Without this tweak it might reproduce 1/10, now is is almost certain (without this included fix).

Fixes: #68 