### PR TITLE
Implement support for MIPS64

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -6,3 +6,4 @@
 Google LLC
 Shawn Anastasio <shawn@anastas.io>
 A. Wilcox <awilfox@adelielinux.org>
+Jiaxun Yang <jiaxun.yang@flygoat.com>

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,9 +91,11 @@ if(NOT MSVC)
         ${MARL_SRC_DIR}/osfiber_arm.c
         ${MARL_SRC_DIR}/osfiber_asm_aarch64.S
         ${MARL_SRC_DIR}/osfiber_asm_arm.S
+        ${MARL_SRC_DIR}/osfiber_asm_mips64.S
         ${MARL_SRC_DIR}/osfiber_asm_ppc64.S
         ${MARL_SRC_DIR}/osfiber_asm_x64.S
         ${MARL_SRC_DIR}/osfiber_asm_x86.S
+        ${MARL_SRC_DIR}/osfiber_mips64.c
         ${MARL_SRC_DIR}/osfiber_ppc64.c
         ${MARL_SRC_DIR}/osfiber_x64.c
         ${MARL_SRC_DIR}/osfiber_x86.c

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Marl is a C++ 11 library that provides a fluent interface for running tasks acro
 
 Marl uses a combination of fibers and threads to allow efficient execution of tasks that can block, while keeping a fixed number of hardware threads.
 
-Marl supports Windows, macOS, Linux, Fuchsia and Android (arm, aarch64, ppc64 (ELFv2), x86 and x64).
+Marl supports Windows, macOS, Linux, Fuchsia and Android (arm, aarch64, mips64, ppc64 (ELFv2), x86 and x64).
 
 Marl has no dependencies on other libraries (with an exception on googletest for building the optional unit tests).
 

--- a/src/osfiber_asm.h
+++ b/src/osfiber_asm.h
@@ -32,6 +32,8 @@
 #include "osfiber_asm_arm.h"
 #elif defined(__powerpc64__)
 #include "osfiber_asm_ppc64.h"
+#elif defined(__mips__) && _MIPS_SIM == _ABI64
+#include "osfiber_asm_mips64.h"
 #else
 #error "Unsupported target"
 #endif

--- a/src/osfiber_asm_mips64.S
+++ b/src/osfiber_asm_mips64.S
@@ -1,0 +1,86 @@
+// Copyright 2020 The Marl Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#if defined(__mips__) && _MIPS_SIM == _ABI64
+
+#define MARL_BUILD_ASM 1
+#include "osfiber_asm_mips64.h"
+
+// void marl_fiber_swap(marl_fiber_context* from, const marl_fiber_context* to)
+// a0: from
+// v0: to
+.text
+.global MARL_ASM_SYMBOL(marl_fiber_swap)
+.align 4
+MARL_ASM_SYMBOL(marl_fiber_swap):
+
+    // Save context 'from'
+
+    // Store callee-preserved registers
+    sd  $s0, MARL_REG_s0($a0)
+    sd  $s1, MARL_REG_s1($a0)
+    sd  $s2, MARL_REG_s2($a0)
+    sd  $s3, MARL_REG_s3($a0)
+    sd  $s4, MARL_REG_s4($a0)
+    sd  $s5, MARL_REG_s5($a0)
+    sd  $s6, MARL_REG_s6($a0)
+    sd  $s7, MARL_REG_s7($a0)
+
+    s.d  $f24, MARL_REG_f24($a0)
+    s.d  $f25, MARL_REG_f25($a0)
+    s.d  $f26, MARL_REG_f26($a0)
+    s.d  $f27, MARL_REG_f27($a0)
+    s.d  $f28, MARL_REG_f28($a0)
+    s.d  $f29, MARL_REG_f29($a0)
+    s.d  $f31, MARL_REG_f30($a0)
+    s.d  $f31, MARL_REG_f31($a0)
+
+    sd  $gp, MARL_REG_gp($a0)
+    sd  $sp, MARL_REG_sp($a0)
+    sd  $fp, MARL_REG_fp($a0)
+    sd  $ra, MARL_REG_ra($a0)
+
+    move  $v0, $a1 // Function have no return, so safe to touch v0
+
+    // Recover callee-preserved registers
+    ld  $s0, MARL_REG_s0($v0)
+    ld  $s1, MARL_REG_s1($v0)
+    ld  $s2, MARL_REG_s2($v0)
+    ld  $s3, MARL_REG_s3($v0)
+    ld  $s4, MARL_REG_s4($v0)
+    ld  $s5, MARL_REG_s5($v0)
+    ld  $s6, MARL_REG_s6($v0)
+    ld  $s7, MARL_REG_s7($v0)
+
+    l.d  $f24, MARL_REG_f24($v0)
+    l.d  $f25, MARL_REG_f25($v0)
+    l.d  $f26, MARL_REG_f26($v0)
+    l.d  $f27, MARL_REG_f27($v0)
+    l.d  $f28, MARL_REG_f28($v0)
+    l.d  $f29, MARL_REG_f29($v0)
+    l.d  $f31, MARL_REG_f30($v0)
+    l.d  $f31, MARL_REG_f31($v0)
+
+    ld  $gp, MARL_REG_gp($v0)
+    ld  $sp, MARL_REG_sp($v0)
+    ld  $fp, MARL_REG_fp($v0)
+    ld  $ra, MARL_REG_ra($v0)
+
+    // Recover arguments
+    ld  $a0, MARL_REG_a0($v0)
+    ld  $a1, MARL_REG_a1($v0)
+
+    jr	$ra
+
+#endif // defined(__mips__) && _MIPS_SIM == _ABI64

--- a/src/osfiber_asm_mips64.h
+++ b/src/osfiber_asm_mips64.h
@@ -1,0 +1,126 @@
+// Copyright 2020 The Marl Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#define MARL_REG_a0 0x00
+#define MARL_REG_a1 0x08
+#define MARL_REG_s0 0x10
+#define MARL_REG_s1 0x18
+#define MARL_REG_s2 0x20
+#define MARL_REG_s3 0x28
+#define MARL_REG_s4 0x30
+#define MARL_REG_s5 0x38
+#define MARL_REG_s6 0x40
+#define MARL_REG_s7 0x48
+#define MARL_REG_f24 0x50
+#define MARL_REG_f25 0x58
+#define MARL_REG_f26 0x60
+#define MARL_REG_f27 0x68
+#define MARL_REG_f28 0x70
+#define MARL_REG_f29 0x78
+#define MARL_REG_f30 0x80
+#define MARL_REG_f31 0x88
+#define MARL_REG_gp 0x90
+#define MARL_REG_sp 0x98
+#define MARL_REG_fp 0xa0
+#define MARL_REG_ra 0xa8
+
+#if defined(__APPLE__)
+#define MARL_ASM_SYMBOL(x) _##x
+#else
+#define MARL_ASM_SYMBOL(x) x
+#endif
+
+#ifndef MARL_BUILD_ASM
+
+#include <stdint.h>
+
+struct marl_fiber_context {
+  // parameter registers (First two)
+  uintptr_t a0;
+  uintptr_t a1;
+
+  // callee-saved registers
+  uintptr_t s0;
+  uintptr_t s1;
+  uintptr_t s2;
+  uintptr_t s3;
+  uintptr_t s4;
+  uintptr_t s5;
+  uintptr_t s6;
+  uintptr_t s7;
+
+  uintptr_t f24;
+  uintptr_t f25;
+  uintptr_t f26;
+  uintptr_t f27;
+  uintptr_t f28;
+  uintptr_t f29;
+  uintptr_t f30;
+  uintptr_t f31;
+
+  uintptr_t gp;
+  uintptr_t sp;
+  uintptr_t fp;
+  uintptr_t ra;
+};
+
+#ifdef __cplusplus
+#include <cstddef>
+static_assert(offsetof(marl_fiber_context, a0) == MARL_REG_a0,
+              "Bad register offset");
+static_assert(offsetof(marl_fiber_context, a1) == MARL_REG_a1,
+              "Bad register offset");
+static_assert(offsetof(marl_fiber_context, s0) == MARL_REG_s0,
+              "Bad register offset");
+static_assert(offsetof(marl_fiber_context, s1) == MARL_REG_s1,
+              "Bad register offset");
+static_assert(offsetof(marl_fiber_context, s2) == MARL_REG_s2,
+              "Bad register offset");
+static_assert(offsetof(marl_fiber_context, s3) == MARL_REG_s3,
+              "Bad register offset");
+static_assert(offsetof(marl_fiber_context, s4) == MARL_REG_s4,
+              "Bad register offset");
+static_assert(offsetof(marl_fiber_context, s5) == MARL_REG_s5,
+              "Bad register offset");
+static_assert(offsetof(marl_fiber_context, s6) == MARL_REG_s6,
+              "Bad register offset");
+static_assert(offsetof(marl_fiber_context, s7) == MARL_REG_s7,
+              "Bad register offset");
+static_assert(offsetof(marl_fiber_context, f24) == MARL_REG_f24,
+              "Bad register offset");
+static_assert(offsetof(marl_fiber_context, f25) == MARL_REG_f25,
+              "Bad register offset");
+static_assert(offsetof(marl_fiber_context, f26) == MARL_REG_f26,
+              "Bad register offset");
+static_assert(offsetof(marl_fiber_context, f27) == MARL_REG_f27,
+              "Bad register offset");
+static_assert(offsetof(marl_fiber_context, f28) == MARL_REG_f28,
+              "Bad register offset");
+static_assert(offsetof(marl_fiber_context, f29) == MARL_REG_f29,
+              "Bad register offset");
+static_assert(offsetof(marl_fiber_context, f30) == MARL_REG_f30,
+              "Bad register offset");
+static_assert(offsetof(marl_fiber_context, f31) == MARL_REG_f31,
+              "Bad register offset");
+static_assert(offsetof(marl_fiber_context, gp) == MARL_REG_gp,
+              "Bad register offset");
+static_assert(offsetof(marl_fiber_context, sp) == MARL_REG_sp,
+              "Bad register offset");
+static_assert(offsetof(marl_fiber_context, fp) == MARL_REG_fp,
+              "Bad register offset");
+static_assert(offsetof(marl_fiber_context, ra) == MARL_REG_ra,
+              "Bad register offset");
+#endif  // __cplusplus
+
+#endif  // MARL_BUILD_ASM

--- a/src/osfiber_mips64.c
+++ b/src/osfiber_mips64.c
@@ -1,0 +1,35 @@
+// Copyright 2020 The Marl Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#if defined(__mips__) && _MIPS_SIM == _ABI64
+
+#include "osfiber_asm_mips64.h"
+
+void marl_fiber_trampoline(void (*target)(void*), void* arg) {
+  target(arg);
+}
+
+void marl_fiber_set_target(struct marl_fiber_context* ctx,
+                           void* stack,
+                           uint32_t stack_size,
+                           void (*target)(void*),
+                           void* arg) {
+  uintptr_t* stack_top = (uintptr_t*)((uint8_t*)(stack) + stack_size);
+  ctx->ra = (uintptr_t)&marl_fiber_trampoline;
+  ctx->a0 = (uintptr_t)target;
+  ctx->a1 = (uintptr_t)arg;
+  ctx->sp = ((uintptr_t)stack_top) & ~(uintptr_t)15;
+}
+
+#endif // defined(__mips__) && _MIPS_SIM == _ABI64


### PR DESCRIPTION
This adds OSFiber support for mips64 with N64 ABI.
It has been tested on a Loongson MIPS64 Little Endian machine,
All unittests green.
