### PR TITLE
Defer benchmark - avoid benchmark::DoNotOptimize()

### DIFF
--- a/src/defer_bench.cpp
+++ b/src/defer_bench.cpp
@@ -16,10 +16,12 @@
 
 #include "benchmark/benchmark.h"
 
+volatile int do_not_optimize_away_result = 0;
+
 static void Defer(benchmark::State& state) {
-  int i = 0;
   for (auto _ : state) {
-    defer(benchmark::DoNotOptimize(i++));
+    // Avoid benchmark::DoNotOptimize() as this is unfairly slower on Windows.
+    defer(do_not_optimize_away_result++);
   }
 }
 BENCHMARK(Defer);


### PR DESCRIPTION
The `benchmark::DoNotOptimize()` implementation is significantly slower on Windows than other OSes, making like-for-like comparisons unfairly disadvantaged for Windows.

Note we still use `benchmark::DoNotOptimize` in the `Schedule/SomeWork`, but this is a far meatier benchmark, where the cost of `benchmark::DoNotOptimize()` is negligible.