### PR TITLE
Fix compiler warnings with MARL_FIBERS_USE_UCONTEXT

### DIFF
--- a/src/osfiber_ucontext.h
+++ b/src/osfiber_ucontext.h
@@ -115,6 +115,7 @@ Allocator::unique_ptr<OSFiber> OSFiber::createFiber(
   out->target = func;
 
   auto res = getcontext(&out->context);
+  (void)res;
   MARL_ASSERT(res == 0, "getcontext() returned %d", int(res));
   out->context.uc_stack.ss_sp = out->stack.ptr;
   out->context.uc_stack.ss_size = stackSize;
@@ -130,6 +131,7 @@ Allocator::unique_ptr<OSFiber> OSFiber::createFiber(
 
 void OSFiber::switchTo(OSFiber* fiber) {
   auto res = swapcontext(&context, &fiber->context);
+  (void)res;
   MARL_ASSERT(res == 0, "swapcontext() returned %d", int(res));
 }
 


### PR DESCRIPTION
The ucontext implementation can be enabled with the `MARL_FIBERS_USE_UCONTEXT` preprocessor define. This is not really used as the assembly implementations tend to be faster, ucontext behaves badly on macOS, and it simply isn't tested as much.

We should make a decision on whether we should just remove this, but until then, let's make sure we're warning-free.