### PR TITLE
Scheduler: document requirement to unbind() before destruction

### DIFF
--- a/include/marl/scheduler.h
+++ b/include/marl/scheduler.h
@@ -43,6 +43,7 @@ using Task = std::function<void()>;
 // A scheduler can be bound to one or more threads using the bind() method.
 // Once bound to a thread, that thread can call marl::schedule() to enqueue
 // work tasks to be executed asynchronously.
+// All threads must be unbound with unbind() before the scheduler is destructed.
 // Scheduler are initially constructed in single-threaded mode.
 // Call setWorkerThreadCount() to spawn dedicated worker threads.
 class Scheduler {
@@ -53,6 +54,10 @@ class Scheduler {
   using Predicate = std::function<bool()>;
 
   Scheduler(Allocator* allocator = Allocator::Default);
+
+  // Destructor.
+  // Ensure that all threads are unbound before calling - failure to do so may
+  // result in leaked memory.
   ~Scheduler();
 
   // get() returns the scheduler bound to the current thread.
@@ -64,6 +69,8 @@ class Scheduler {
 
   // unbind() unbinds the scheduler currently bound to the current thread.
   // There must be a existing scheduler bound to the thread prior to calling.
+  // unbind() flushes any enqueued tasks on the single-threaded worker before
+  // returning.
   static void unbind();
 
   // enqueue() queues the task for asynchronous execution.

--- a/src/scheduler.cpp
+++ b/src/scheduler.cpp
@@ -133,12 +133,17 @@ Scheduler::Scheduler(Allocator* allocator /* = Allocator::Default */)
 }
 
 Scheduler::~Scheduler() {
+#if MARL_DEBUG_ENABLED
   {
     std::unique_lock<std::mutex> lock(singleThreadedWorkerMutex);
     MARL_ASSERT(singleThreadedWorkers.size() == 0,
                 "Scheduler still bound on %d threads",
                 int(singleThreadedWorkers.size()));
   }
+#endif  // MARL_DEBUG_ENABLED
+
+  // Release all worker threads.
+  // This will wait for all in-flight tasks to complete before returning.
   setWorkerThreadCount(0);
 }
 


### PR DESCRIPTION
Based on the discussions of #79