### PR TITLE
Scheduler: Replace use of std::thread with marl::Thread

### DIFF
--- a/include/marl/scheduler.h
+++ b/include/marl/scheduler.h
@@ -18,6 +18,7 @@
 #include "debug.h"
 #include "memory.h"
 #include "sal.h"
+#include "thread.h"
 
 #include <array>
 #include <atomic>
@@ -411,7 +412,7 @@ class Scheduler {
     Scheduler* const scheduler;
     Allocator::unique_ptr<Fiber> mainFiber;
     Fiber* currentFiber = nullptr;
-    std::thread thread;
+    Thread thread;
     Work work;
     FiberSet idleFibers;  // Fibers that have completed which can be reused.
     std::vector<Allocator::unique_ptr<Fiber>>

--- a/src/scheduler.cpp
+++ b/src/scheduler.cpp
@@ -361,7 +361,7 @@ Scheduler::Worker::Worker(Scheduler* scheduler, Mode mode, uint32_t id)
 void Scheduler::Worker::start() {
   switch (mode) {
     case Mode::MultiThreaded:
-      thread = std::thread([=] {
+      thread = Thread(id, [=] {
         Thread::setName("Thread<%.2d>", int(id));
 
         if (auto const& initFunc = scheduler->getThreadInitializer()) {

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -14,6 +14,8 @@
 
 #include "marl/thread.h"
 
+#include "marl/debug.h"
+#include "marl/defer.h"
 #include "marl/trace.h"
 
 #include <cstdarg>
@@ -22,19 +24,148 @@
 #if defined(_WIN32)
 #define WIN32_LEAN_AND_MEAN 1
 #include <windows.h>
-#include <cstdlib> // mbstowcs
+#include <condition_variable>
+#include <cstdlib>  // mbstowcs
+#include <mutex>
+#include <vector>
 #elif defined(__APPLE__)
 #include <mach/thread_act.h>
 #include <pthread.h>
 #include <unistd.h>
+#include <thread>
 #else
 #include <pthread.h>
 #include <unistd.h>
+#include <thread>
 #endif
 
 namespace marl {
 
 #if defined(_WIN32)
+
+#define CHECK_WIN32(expr)                                    \
+  do {                                                       \
+    auto res = expr;                                         \
+    (void)res;                                               \
+    MARL_ASSERT(res == TRUE, #expr " failed with error: %d", \
+                (int)GetLastError());                        \
+  } while (false)
+
+namespace {
+
+struct ProcessorGroup {
+  unsigned int count;  // number of logical processors in this group.
+  KAFFINITY affinity;  // affinity mask.
+};
+
+const std::vector<ProcessorGroup>& getProcessorGroups() {
+  static std::vector<ProcessorGroup> groups = [] {
+    std::vector<ProcessorGroup> out;
+    SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX info[32] = {};
+    DWORD size = sizeof(info);
+    CHECK_WIN32(GetLogicalProcessorInformationEx(RelationGroup, info, &size));
+    DWORD count = size / sizeof(SYSTEM_LOGICAL_PROCESSOR_INFORMATION_EX);
+    for (DWORD i = 0; i < count; i++) {
+      if (info[i].Relationship == RelationGroup) {
+        auto groupCount = info[i].Group.ActiveGroupCount;
+        for (WORD groupIdx = 0; groupIdx < groupCount; groupIdx++) {
+          auto const& groupInfo = info[i].Group.GroupInfo;
+          out.emplace_back(ProcessorGroup{groupInfo->ActiveProcessorCount,
+                                          groupInfo->ActiveProcessorMask});
+        }
+      }
+    }
+    return out;
+  }();
+  return groups;
+}
+
+bool getGroupAffinity(unsigned int index, GROUP_AFFINITY* groupAffinity) {
+  auto& groups = getProcessorGroups();
+  for (size_t groupIdx = 0; groupIdx < groups.size(); groupIdx++) {
+    auto& group = groups[groupIdx];
+    if (index < group.count) {
+      for (int i = 0; i < sizeof(group.affinity) * 8; i++) {
+        if (group.affinity & (1ULL << i)) {
+          if (index == 0) {
+            groupAffinity->Group = static_cast<WORD>(groupIdx);
+            // Use the whole group's affinity, as the OS is then able to shuffle
+            // threads around based on external demands. Pinning these to a
+            // single core can cause up to 20% performance loss in benchmarking.
+            groupAffinity->Mask = group.affinity;
+            return true;
+          }
+          index--;
+        }
+      }
+      return false;
+    } else {
+      index -= group.count;
+    }
+  }
+  return false;
+}
+
+}  // namespace
+
+class Thread::Impl {
+ public:
+  Impl(const Func& func) : func(func) {}
+  static DWORD WINAPI run(void* self) {
+    reinterpret_cast<Impl*>(self)->run();
+    return 0;
+  }
+
+  void run() {
+    func();
+    func = Func();
+    std::unique_lock<std::mutex> lock(mutex);
+    finished = true;
+    cv.notify_all();
+  }
+
+  Func func;
+  std::mutex mutex;
+  HANDLE handle;
+  std::condition_variable cv;  // guarded by mutex.
+  bool finished = false;       // guarded by mutex.
+};
+
+Thread::Thread(unsigned int logicalCpu, const Func& func) {
+  SIZE_T size = 0;
+  InitializeProcThreadAttributeList(nullptr, 1, 0, &size);
+  MARL_ASSERT(size > 0,
+              "InitializeProcThreadAttributeList() did not give a size");
+
+  LPPROC_THREAD_ATTRIBUTE_LIST attributes =
+      reinterpret_cast<LPPROC_THREAD_ATTRIBUTE_LIST>(alloca(size));
+  CHECK_WIN32(InitializeProcThreadAttributeList(attributes, 1, 0, &size));
+  defer(DeleteProcThreadAttributeList(attributes));
+
+  GROUP_AFFINITY groupAffinity = {};
+  if (getGroupAffinity(logicalCpu, &groupAffinity)) {
+    CHECK_WIN32(UpdateProcThreadAttribute(
+        attributes, 0, PROC_THREAD_ATTRIBUTE_GROUP_AFFINITY, &groupAffinity,
+        sizeof(groupAffinity), nullptr, nullptr));
+  }
+
+  impl = new Impl(func);
+  impl->handle = CreateRemoteThreadEx(GetCurrentProcess(), nullptr, 0,
+                                      &Impl::run, impl, 0, attributes, nullptr);
+}
+
+Thread::~Thread() {
+  if (impl) {
+    CloseHandle(impl->handle);
+    delete impl;
+  }
+}
+
+void Thread::join() {
+  MARL_ASSERT(impl != nullptr, "join() called on unjoinable thread");
+  std::unique_lock<std::mutex> lock(impl->mutex);
+  impl->cv.wait(lock, [&] { return impl->finished; });
+}
 
 void Thread::setName(const char* fmt, ...) {
   static auto setThreadDescription =
@@ -57,24 +188,32 @@ void Thread::setName(const char* fmt, ...) {
 }
 
 unsigned int Thread::numLogicalCPUs() {
-  DWORD_PTR processAffinityMask = 1;
-  DWORD_PTR systemAffinityMask = 1;
-
-  GetProcessAffinityMask(GetCurrentProcess(), &processAffinityMask,
-                         &systemAffinityMask);
-
-  auto count = 0;
-  while (processAffinityMask > 0) {
-    if (processAffinityMask & 1) {
-      count++;
-    }
-
-    processAffinityMask >>= 1;
+  unsigned int count = 0;
+  for (auto& group : getProcessorGroups()) {
+    count += group.count;
   }
   return count;
 }
 
 #else
+
+class Thread::Impl {
+ public:
+  template <typename F>
+  Impl(F&& func) : thread(func) {}
+  std::thread thread;
+};
+
+Thread::Thread(unsigned int /* logicalCpu */, const Func& func)
+    : impl(new Thread::Impl(func)) {}
+
+Thread::~Thread() {
+  delete impl;
+}
+
+void Thread::join() {
+  impl->thread.join();
+}
 
 void Thread::setName(const char* fmt, ...) {
   char name[1024];
@@ -96,6 +235,20 @@ unsigned int Thread::numLogicalCPUs() {
   return sysconf(_SC_NPROCESSORS_ONLN);
 }
 
-#endif
+#endif  // OS
+
+Thread::Thread(Thread&& rhs) : impl(rhs.impl) {
+  rhs.impl = nullptr;
+}
+
+Thread& Thread::operator=(Thread&& rhs) {
+  if (impl) {
+    delete impl;
+    impl = nullptr;
+  }
+  impl = rhs.impl;
+  rhs.impl = nullptr;
+  return *this;
+}
 
 }  // namespace marl


### PR DESCRIPTION
Implement `marl::Thread` as an abstraction of `std::thread` so we can scale beyond 64 threads on a single CPU.

Fixes: #87