### PR TITLE
thread.cpp Fix minor bug in getProcessorGroups()

### DIFF
--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -69,9 +69,9 @@ const std::vector<ProcessorGroup>& getProcessorGroups() {
       if (info[i].Relationship == RelationGroup) {
         auto groupCount = info[i].Group.ActiveGroupCount;
         for (WORD groupIdx = 0; groupIdx < groupCount; groupIdx++) {
-          auto const& groupInfo = info[i].Group.GroupInfo;
-          out.emplace_back(ProcessorGroup{groupInfo->ActiveProcessorCount,
-                                          groupInfo->ActiveProcessorMask});
+          auto const& groupInfo = info[i].Group.GroupInfo[groupIdx];
+          out.emplace_back(ProcessorGroup{groupInfo.ActiveProcessorCount,
+                                          groupInfo.ActiveProcessorMask});
         }
       }
     }


### PR DESCRIPTION
We were looping over the active processor groups, but only using the `ActiveProcessorCount` and `ActiveProcessorMask` from the first group.
It is extremely unlikely that these would be different for multi-cpu systems, but a bug none the less.