### PR TITLE
thread.cpp: Replace use of alloca with vector.

### DIFF
--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -124,8 +124,9 @@ Thread::Thread(unsigned int logicalCpu, const Func& func) {
   MARL_ASSERT(size > 0,
               "InitializeProcThreadAttributeList() did not give a size");
 
+  std::vector<uint8_t> buffer(size);
   LPPROC_THREAD_ATTRIBUTE_LIST attributes =
-      reinterpret_cast<LPPROC_THREAD_ATTRIBUTE_LIST>(alloca(size));
+      reinterpret_cast<LPPROC_THREAD_ATTRIBUTE_LIST>(buffer.data());
   CHECK_WIN32(InitializeProcThreadAttributeList(attributes, 1, 0, &size));
   defer(DeleteProcThreadAttributeList(attributes));
 


### PR DESCRIPTION
`alloca` is actually officially `_alloca` on windows, but the former seems to compile on _some_ toolchains.

Given that the threads are not often created, just take the hit of using a heap allocation. At least this won't deal with stack overflow issues or weird differences in naming.