### PR TITLE
Scheduler: Reduce the number of mutex locks / unlock.

### DIFF
--- a/include/marl/scheduler.h
+++ b/include/marl/scheduler.h
@@ -337,14 +337,17 @@ class Scheduler {
     // continue to process tasks until stop() is called.
     // If the worker was constructed in Mode::SingleThreaded, run() call
     // flush() and return.
+    _Requires_lock_held_(work.mutex)
     void run();
 
     // createWorkerFiber() creates a new fiber that when executed calls
     // run().
+    _Requires_lock_held_(work.mutex)
     Fiber* createWorkerFiber();
 
     // switchToFiber() switches execution to the given fiber. The fiber
     // must belong to this worker.
+    _Requires_lock_held_(work.mutex)
     void switchToFiber(Fiber*);
 
     // runUntilIdle() executes all pending tasks and then returns.


### PR DESCRIPTION
Keep the worker mutex locked between fiber switches.
This obviously keeps the lock held longer, but there are substantial gains in not locking and unlocking so frequently.

Reduces times of most EventBaton tests by 1.12x