### PR TITLE
Fixes for x86.

### DIFF
--- a/src/osfiber_x86.c
+++ b/src/osfiber_x86.c
@@ -25,12 +25,19 @@ void marl_fiber_set_target(struct marl_fiber_context* ctx,
                            uint32_t stack_size,
                            void (*target)(void*),
                            void* arg) {
+  // The stack pointer needs to be 16-byte aligned when making a 'call'.
+  // The 'call' instruction automatically pushes the return instruction to the
+  // stack (4-bytes), before making the jump.
+  // The marl_fiber_swap() assembly function does not use 'call', instead it
+  // uses 'jmp', so we need to offset the ESP pointer by 4 bytes so that the
+  // stack is still 16-byte aligned when the return target is stack-popped by
+  // the callee.
   uintptr_t* stack_top = (uintptr_t*)((uint8_t*)(stack) + stack_size);
   ctx->EIP = (uintptr_t)&marl_fiber_trampoline;
-  ctx->ESP = (uintptr_t)&stack_top[-3];
-  stack_top[-1] = (uintptr_t)arg;
-  stack_top[-2] = (uintptr_t)target;
-  stack_top[-3] = 0;  // No return target.
+  ctx->ESP = (uintptr_t)&stack_top[-5];
+  stack_top[-3] = (uintptr_t)arg;
+  stack_top[-4] = (uintptr_t)target;
+  stack_top[-5] = 0;  // No return target.
 }
 
 #endif  // defined(__i386__)

--- a/src/scheduler_test.cpp
+++ b/src/scheduler_test.cpp
@@ -107,11 +107,14 @@ TEST_P(WithBoundScheduler, FibersResumeOnSameThread) {
 TEST_P(WithBoundScheduler, FibersResumeOnSameStdThread) {
   auto scheduler = marl::Scheduler::get();
 
+  // on 32-bit OSs, excessive numbers of threads can run out of address space.
+  constexpr auto num_threads = sizeof(void*) > 4 ? 1000 : 100;
+
   marl::WaitGroup fence(1);
-  marl::WaitGroup wg(1000);
+  marl::WaitGroup wg(num_threads);
 
   std::vector<std::thread> threads;
-  for (int i = 0; i < 1000; i++) {
+  for (int i = 0; i < num_threads; i++) {
     threads.push_back(std::thread([=] {
       scheduler->bind();
 


### PR DESCRIPTION
Make sure the fiber stack is 16 byte aligned. This was off by 4 bytes, causing some mmx instructions to fault due to stack misalignment.

Also fix `WithBoundScheduler.FibersResumeOnSameStdThread` which would crash due to the excessive number of threads spawned, which would cause the process to run out of address space.