### PR TITLE
CMake: link with pthread in a CMake way

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -146,7 +146,7 @@ function(marl_set_target_options target)
         target_link_libraries(${target} "-fsanitize=thread")
     endif()
 
-    target_include_directories(${target} PUBLIC ${MARL_INCLUDE_DIR})
+    target_include_directories(${target} PUBLIC $<BUILD_INTERFACE:${MARL_INCLUDE_DIR}>)
 endfunction(marl_set_target_options)
 
 ###########################################################

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,13 +105,7 @@ endif(NOT MSVC)
 ###########################################################
 # OS libraries
 ###########################################################
-if(CMAKE_SYSTEM_NAME MATCHES "Windows")
-    set(MARL_OS_LIBS Kernel32)
-elseif(CMAKE_SYSTEM_NAME MATCHES "Linux")
-    set(MARL_OS_LIBS pthread)
-elseif(CMAKE_SYSTEM_NAME MATCHES "Darwin")
-    set(MARL_OS_LIBS)
-endif()
+find_package(Threads REQUIRED)
 
 ###########################################################
 # Functions
@@ -167,11 +161,18 @@ set_target_properties(marl PROPERTIES
 
 marl_set_target_options(marl)
 
-target_link_libraries(marl "${MARL_OS_LIBS}")
+target_link_libraries(marl PUBLIC Threads::Threads)
 
 # install
 if(MARL_INSTALL)
+    include(CMakePackageConfigHelpers)
     include(GNUInstallDirs)
+
+    configure_package_config_file(
+        ${CMAKE_CURRENT_SOURCE_DIR}/cmake/marl-config.cmake.in
+        ${CMAKE_CURRENT_BINARY_DIR}/marl-config.cmake
+        INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/marl
+    )
 
     install(DIRECTORY ${MARL_INCLUDE_DIR}/marl
         DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
@@ -187,8 +188,12 @@ if(MARL_INSTALL)
     )
 
     install(EXPORT marl-targets
-        FILE marl-config.cmake
+        FILE marl-targets.cmake
         NAMESPACE marl::
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/marl
+    )
+
+    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/marl-config.cmake
         DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/marl
     )
 endif(MARL_INSTALL)

--- a/cmake/marl-config.cmake.in
+++ b/cmake/marl-config.cmake.in
@@ -1,0 +1,9 @@
+@PACKAGE_INIT@
+
+include(CMakeFindDependencyMacro)
+
+find_dependency(Threads)
+
+if(NOT TARGET marl::marl)
+    include(${CMAKE_CURRENT_LIST_DIR}/marl-targets.cmake)
+endif()


### PR DESCRIPTION
Hi! @ben-clayton Sorry for the long delay.
This patch is based on this discussion: [cmake and libpthread])https://stackoverflow.com/questions/1620918/cmake-and-libpthread).

The difference is that, by using:
```cmake
target_link_libraries(myproject PUBLIC Threads::Threads)
```
an additional flag `-pthread` is added when compiling. And it may make a difference sometimes: [Significance of -pthread flag when compiling](https://stackoverflow.com/questions/2127797/significance-of-pthread-flag-when-compiling).