### PR TITLE
CMake: Export MARL_THREAD_SAFETY_ANALYSIS_SUPPORTED

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,6 +100,9 @@ check_cxx_source_compiles(
     MARL_THREAD_SAFETY_ANALYSIS_SUPPORTED)
 set(CMAKE_REQUIRED_FLAGS ${SAVE_CMAKE_REQUIRED_FLAGS})
 
+# Export MARL_THREAD_SAFETY_ANALYSIS_SUPPORTED as this may be useful to parent projects
+set(MARL_THREAD_SAFETY_ANALYSIS_SUPPORTED PARENT_SCOPE ${MARL_THREAD_SAFETY_ANALYSIS_SUPPORTED})
+
 ###########################################################
 # File lists
 ###########################################################


### PR DESCRIPTION
... to parent scope.

If projects want to use Clang's TSA annotations (especially if they're using `marl/tsa.h`), they likely do not want to have to duplicate the compiler bug check that marl performs.

This is such a unique name I do not feel there's any issues about polluting the parent scope with this variable.