### PR TITLE
Pool::Loan::get(): Return nullptr if has no item.

### DIFF
--- a/include/marl/pool.h
+++ b/include/marl/pool.h
@@ -192,7 +192,7 @@ T* Pool<T>::Loan::operator->() const {
 
 template <typename T>
 T* Pool<T>::Loan::get() const {
-  return item->get();
+  return item ? item->get() : nullptr;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/src/pool_test.cpp
+++ b/src/pool_test.cpp
@@ -26,6 +26,16 @@ TEST_P(WithBoundScheduler, BoundedPool_ConstructDestruct) {
   marl::BoundedPool<int, 10> pool;
 }
 
+TEST_P(WithBoundScheduler, UnboundedPoolLoan_GetNull) {
+  marl::UnboundedPool<int>::Loan loan;
+  ASSERT_EQ(loan.get(), nullptr);
+}
+
+TEST_P(WithBoundScheduler, BoundedPoolLoan_GetNull) {
+  marl::BoundedPool<int, 10>::Loan loan;
+  ASSERT_EQ(loan.get(), nullptr);
+}
+
 TEST_P(WithBoundScheduler, UnboundedPool_Borrow) {
   marl::UnboundedPool<int> pool;
   for (int i = 0; i < 100; i++) {


### PR DESCRIPTION
Instead of deferencing the nullptr item.

Upstreaming change cl/308295787.