### PR TITLE
Reduce size of marl::ConditionVariable

### DIFF
--- a/include/marl/event.h
+++ b/include/marl/event.h
@@ -26,7 +26,7 @@ namespace marl {
 // Event is a synchronization primitive used to block until a signal is raised.
 class Event {
  public:
-  enum class Mode {
+  enum class Mode : uint8_t {
     // The event signal will be automatically reset when a call to wait()
     // returns.
     // A single call to signal() will only unblock a single (possibly
@@ -115,9 +115,9 @@ class Event {
 
     marl::mutex mutex;
     ConditionVariable cv;
+    containers::vector<std::shared_ptr<Shared>, 1> deps;
     const Mode mode;
     bool signalled;
-    containers::vector<std::shared_ptr<Shared>, 2> deps;
   };
 
   const std::shared_ptr<Shared> shared;

--- a/include/marl/memory.h
+++ b/include/marl/memory.h
@@ -31,10 +31,15 @@ namespace marl {
 // system.
 size_t pageSize();
 
+template <typename T>
+inline T alignUp(T val, T alignment) {
+  return alignment * ((val + alignment - 1) / alignment);
+}
+
 // Allocation holds the result of a memory allocation from an Allocator.
 struct Allocation {
   // Intended usage of the allocation. Used for allocation trackers.
-  enum class Usage {
+  enum class Usage : uint8_t {
     Undefined = 0,
     Stack,   // Fiber stack
     Create,  // Allocator::create(), make_unique(), make_shared()

--- a/src/event_test.cpp
+++ b/src/event_test.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "marl/event.h"
+#include "marl/defer.h"
 #include "marl/waitgroup.h"
 
 #include "marl_test.h"

--- a/src/memory.cpp
+++ b/src/memory.cpp
@@ -129,11 +129,6 @@ inline void protectPage(void* addr) {
 
 namespace {
 
-template <typename T>
-inline T alignUp(T val, T alignment) {
-  return alignment * ((val + alignment - 1) / alignment);
-}
-
 // pagedMalloc() allocates size bytes of uninitialized storage with the
 // specified minimum byte alignment using OS specific page mapping calls.
 // If guardLow is true then reads or writes to the page below the returned
@@ -188,8 +183,8 @@ void pagedFree(void* ptr,
 inline void* alignedMalloc(size_t alignment, size_t size) {
   size_t allocSize = size + alignment + sizeof(void*);
   auto allocation = malloc(allocSize);
-  auto aligned = reinterpret_cast<uint8_t*>(
-      alignUp(reinterpret_cast<uintptr_t>(allocation), alignment));  // align
+  auto aligned = reinterpret_cast<uint8_t*>(marl::alignUp(
+      reinterpret_cast<uintptr_t>(allocation), alignment));  // align
   memcpy(aligned + size, &allocation, sizeof(void*));  // pointer-to-allocation
   return aligned;
 }


### PR DESCRIPTION
This had grown to a whopping 456 bytes on x64.
Rework the structures to reduce this down to a more reasonable 144 bytes.

Also:
* Remove the use  and include of `defer` in `conditionvariable.h`. We should not be including `defer.h` in any public header.
* Only allocate the list when needed. Removes unnecessary heap allocations.