### PR TITLE
Add tests for using a marl::Scheduler without binding

### DIFF
--- a/src/scheduler_test.cpp
+++ b/src/scheduler_test.cpp
@@ -15,6 +15,7 @@
 #include "marl_test.h"
 
 #include "marl/defer.h"
+#include "marl/event.h"
 #include "marl/waitgroup.h"
 
 #include <atomic>
@@ -117,13 +118,12 @@ TEST_P(WithBoundScheduler, FibersResumeOnSameStdThread) {
   for (int i = 0; i < num_threads; i++) {
     threads.push_back(std::thread([=] {
       scheduler->bind();
+      defer(scheduler->unbind());
 
       auto threadID = std::this_thread::get_id();
       fence.wait();
       ASSERT_EQ(threadID, std::this_thread::get_id());
       wg.done();
-
-      scheduler->unbind();
     }));
   }
   // just to try and get some tasks to yield.
@@ -139,6 +139,7 @@ TEST_P(WithBoundScheduler, FibersResumeOnSameStdThread) {
 TEST_F(WithoutBoundScheduler, TasksOnlyScheduledOnWorkerThreads) {
   auto scheduler = std::unique_ptr<marl::Scheduler>(new marl::Scheduler());
   scheduler->bind();
+  defer(scheduler->unbind());
   scheduler->setWorkerThreadCount(8);
   std::mutex mutex;
   std::unordered_set<std::thread::id> threads;
@@ -155,6 +156,47 @@ TEST_F(WithoutBoundScheduler, TasksOnlyScheduledOnWorkerThreads) {
 
   ASSERT_LE(threads.size(), 8U);
   ASSERT_EQ(threads.count(std::this_thread::get_id()), 0U);
+}
 
-  scheduler->unbind();
+// Test that a marl::Scheduler *with dedicated worker threads* can be used
+// without first binding to the scheduling thread.
+TEST_F(WithoutBoundScheduler, ScheduleMTWWithNoBind) {
+  auto scheduler = std::unique_ptr<marl::Scheduler>(new marl::Scheduler());
+  scheduler->setWorkerThreadCount(8);
+
+  marl::WaitGroup wg;
+  for (int i = 0; i < 100; i++) {
+    wg.add(1);
+
+    marl::Event event;
+    scheduler->enqueue(marl::Task([event, wg] {
+      event.wait();  // Test that tasks can wait on other tasks.
+      wg.done();
+    }));
+
+    scheduler->enqueue(marl::Task([event, &scheduler] {
+      // Despite the main thread never binding the scheduler, the scheduler
+      // should be automatically bound to worker threads.
+      ASSERT_EQ(marl::Scheduler::get(), scheduler.get());
+
+      event.signal();
+    }));
+  }
+
+  // As the scheduler has not been bound to the main thread, the wait() call
+  // here will block **without** fiber yielding.
+  wg.wait();
+}
+
+// Test that a marl::Scheduler *without dedicated worker threads* cannot be used
+// without first binding to the scheduling thread.
+TEST_F(WithoutBoundScheduler, ScheduleSTWWithNoBind) {
+  auto scheduler = std::unique_ptr<marl::Scheduler>(new marl::Scheduler());
+
+#if MARL_DEBUG_ENABLED
+  EXPECT_DEATH(scheduler->enqueue(marl::Task([] {})),
+               "Did you forget to call marl::Scheduler::bind");
+#else
+  scheduler->enqueue(marl::Task([] { FAIL() << "Should not be called"; }));
+#endif
 }


### PR DESCRIPTION
A `marl::Scheduler` can be used to enqueue tasks without first binding to the scheduling thread so long as there are dedicated worker threads.

Issue: #130