### PR TITLE
Enable FreeBSD support

### DIFF
--- a/src/memory.cpp
+++ b/src/memory.cpp
@@ -19,7 +19,7 @@
 
 #include <cstring>
 
-#if defined(__linux__) || defined(__APPLE__)
+#if defined(__linux__) || defined(__FreeBSD__) ||  defined(__APPLE__)
 #include <sys/mman.h>
 #include <unistd.h>
 namespace {

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -31,6 +31,11 @@
 #include <pthread.h>
 #include <unistd.h>
 #include <thread>
+#elif defined(__FreeBSD__)
+#include <pthread.h>
+#include <pthread_np.h>
+#include <unistd.h>
+#include <thread>
 #else
 #include <pthread.h>
 #include <unistd.h>
@@ -211,6 +216,8 @@ void Thread::setName(const char* fmt, ...) {
 
 #if defined(__APPLE__)
   pthread_setname_np(name);
+#elif defined(__FreeBSD__)
+  pthread_set_name_np(pthread_self(), name);
 #elif !defined(__Fuchsia__)
   pthread_setname_np(pthread_self(), name);
 #endif


### PR DESCRIPTION
That one was easy. Just some Pre-Proc macros and `pthread_set_name_np`. All examples ran fine.

Thanks for this nice library!