### PR TITLE
Test build / warning fixes for iOS

### DIFF
--- a/src/memory_test.cpp
+++ b/src/memory_test.cpp
@@ -78,6 +78,7 @@ TEST_F(AllocatorTest, Create) {
   allocator->destroy(s16);
 }
 
+#if GTEST_HAS_DEATH_TEST
 TEST_F(AllocatorTest, Guards) {
   marl::Allocation::Request request;
   request.alignment = 16;
@@ -88,3 +89,4 @@ TEST_F(AllocatorTest, Guards) {
   EXPECT_DEATH(ptr[-1] = 1, "");
   EXPECT_DEATH(ptr[marl::pageSize()] = 1, "");
 }
+#endif

--- a/src/osfiber_asm.h
+++ b/src/osfiber_asm.h
@@ -119,9 +119,9 @@ Allocator::unique_ptr<OSFiber> OSFiber::createFiber(
   out->context = {};
   out->target = func;
   out->stack = allocator->allocate(request);
-  marl_fiber_set_target(&out->context, out->stack.ptr, stackSize,
-                        reinterpret_cast<void (*)(void*)>(&OSFiber::run),
-                        out.get());
+  marl_fiber_set_target(
+      &out->context, out->stack.ptr, static_cast<uint32_t>(stackSize),
+      reinterpret_cast<void (*)(void*)>(&OSFiber::run), out.get());
   return out;
 }
 

--- a/src/scheduler_test.cpp
+++ b/src/scheduler_test.cpp
@@ -193,10 +193,10 @@ TEST_F(WithoutBoundScheduler, ScheduleMTWWithNoBind) {
 TEST_F(WithoutBoundScheduler, ScheduleSTWWithNoBind) {
   auto scheduler = std::unique_ptr<marl::Scheduler>(new marl::Scheduler());
 
-#if MARL_DEBUG_ENABLED
+#if MARL_DEBUG_ENABLED && GTEST_HAS_DEATH_TEST
   EXPECT_DEATH(scheduler->enqueue(marl::Task([] {})),
                "Did you forget to call marl::Scheduler::bind");
-#else
+#elif !MARL_DEBUG_ENABLED
   scheduler->enqueue(marl::Task([] { FAIL() << "Should not be called"; }));
 #endif
 }

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -226,7 +226,7 @@ void Thread::setName(const char* fmt, ...) {
 }
 
 unsigned int Thread::numLogicalCPUs() {
-  return sysconf(_SC_NPROCESSORS_ONLN);
+  return static_cast<unsigned int>(sysconf(_SC_NPROCESSORS_ONLN));
 }
 
 #endif  // OS

--- a/src/waitgroup_test.cpp
+++ b/src/waitgroup_test.cpp
@@ -22,14 +22,14 @@ TEST_F(WithoutBoundScheduler, WaitGroupDone) {
   wg.done();
 }
 
-#if MARL_DEBUG_ENABLED
+#if MARL_DEBUG_ENABLED && GTEST_HAS_DEATH_TEST
 TEST_F(WithoutBoundScheduler, WaitGroupDoneTooMany) {
   marl::WaitGroup wg(2);  // Should not require a scheduler.
   wg.done();
   wg.done();
   EXPECT_DEATH(wg.done(), "done\\(\\) called too many times");
 }
-#endif  // MARL_DEBUG_ENABLED
+#endif  // MARL_DEBUG_ENABLED && GTEST_HAS_DEATH_TEST
 
 TEST_P(WithBoundScheduler, WaitGroup_OneTask) {
   marl::WaitGroup wg(1);


### PR DESCRIPTION
googletest's EXPECT_DEATH is not supported on iOS, so disable those tests.
Also fix a couple of compiler warnings that were raised.

Issue: #126