### PR TITLE
Don't use deprecated scheduler methods and warn if used

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,11 +23,10 @@ Example:
 #include <cstdio>
 
 int main() {
-  // Create a marl scheduler using the 4 hardware threads.
+  // Create a marl scheduler using all the logical processors available to the process.
   // Bind this scheduler to the main thread so we can call marl::schedule()
-  marl::Scheduler scheduler;
+  marl::Scheduler scheduler(marl::Scheduler::Config::allCores());
   scheduler.bind();
-  scheduler.setWorkerThreadCount(4);
   defer(scheduler.unbind());  // Automatically unbind before returning.
 
   constexpr int numTasks = 10;
@@ -140,7 +139,7 @@ Internally, these primitives hold a shared pointer to the primitive state. By ca
 
 #### Create one instance of `marl::Scheduler`, use it for the lifetime of the process.
 
-`marl::Scheduler::setWorkerThreadCount()` is an expensive operation as it spawn a number of hardware threads. \
+The `marl::Scheduler` constructor can be expensive as it may spawn a number of hardware threads. \
 Destructing the `marl::Scheduler` requires waiting on all tasks to complete.
 
 Multiple `marl::Scheduler`s may fight each other for hardware thread utilization.
@@ -151,9 +150,8 @@ For example:
 
 ```c++
 int main() {
-  marl::Scheduler scheduler;
+  marl::Scheduler scheduler(marl::Scheduler::Config::allCores());
   scheduler.bind();
-  scheduler.setWorkerThreadCount(marl::Thread::numLogicalCPUs());
   defer(scheduler.unbind());
 
   return do_program_stuff();

--- a/examples/fractal.cpp
+++ b/examples/fractal.cpp
@@ -149,8 +149,7 @@ constexpr float cy = 0.156f;
 int main() {
   // Create a marl scheduler using the full number of logical cpus.
   // Bind this scheduler to the main thread so we can call marl::schedule()
-  marl::Scheduler scheduler;
-  scheduler.setWorkerThreadCount(marl::Thread::numLogicalCPUs());
+  marl::Scheduler scheduler(marl::Scheduler::Config::allCores());
   scheduler.bind();
   defer(scheduler.unbind());  // unbind before destructing the scheduler.
 

--- a/examples/hello_task.cpp
+++ b/examples/hello_task.cpp
@@ -24,9 +24,11 @@
 int main() {
   // Create a marl scheduler using the 4 hardware threads.
   // Bind this scheduler to the main thread so we can call marl::schedule()
-  marl::Scheduler scheduler;
+  marl::Scheduler::Config cfg;
+  cfg.setWorkerThreadCount(4);
+
+  marl::Scheduler scheduler(cfg);
   scheduler.bind();
-  scheduler.setWorkerThreadCount(4);
   defer(scheduler.unbind());  // Automatically unbind before returning.
 
   constexpr int numTasks = 10;

--- a/examples/primes.cpp
+++ b/examples/primes.cpp
@@ -42,8 +42,7 @@ bool isPrime(int i) {
 int main() {
   // Create a marl scheduler using the full number of logical cpus.
   // Bind this scheduler to the main thread so we can call marl::schedule()
-  marl::Scheduler scheduler;
-  scheduler.setWorkerThreadCount(marl::Thread::numLogicalCPUs());
+  marl::Scheduler scheduler(marl::Scheduler::Config::allCores());
   scheduler.bind();
   defer(scheduler.unbind());  // unbind before destructing the scheduler.
 

--- a/examples/tasks_in_tasks.cpp
+++ b/examples/tasks_in_tasks.cpp
@@ -23,9 +23,11 @@
 int main() {
   // Create a marl scheduler using the 4 hardware threads.
   // Bind this scheduler to the main thread so we can call marl::schedule()
-  marl::Scheduler scheduler;
+  marl::Scheduler::Config cfg;
+  cfg.setWorkerThreadCount(4);
+
+  marl::Scheduler scheduler(cfg);
   scheduler.bind();
-  scheduler.setWorkerThreadCount(4);
   defer(scheduler.unbind());  // Automatically unbind before returning.
 
   // marl::schedule() requires the scheduler to be bound to the current thread

--- a/include/marl/deprecated.h
+++ b/include/marl/deprecated.h
@@ -24,11 +24,15 @@
 #endif  // MARL_ENABLE_DEPRECATED_SCHEDULER_GETTERS_SETTERS
 
 #ifndef MARL_WARN_DEPRECATED
-#define MARL_WARN_DEPRECATED 0
+#define MARL_WARN_DEPRECATED 1
 #endif  // MARL_WARN_DEPRECATED
 
 #if MARL_WARN_DEPRECATED
+#if defined(_WIN32)
+#define MARL_DEPRECATED(message) __declspec(deprecated(message))
+#else
 #define MARL_DEPRECATED(message) __attribute__((deprecated(message)))
+#endif
 #else
 #define MARL_DEPRECATED(message)
 #endif

--- a/src/marl_bench.h
+++ b/src/marl_bench.h
@@ -28,8 +28,10 @@ class Schedule : public benchmark::Fixture {
   // F must be a function of the signature: void(int numTasks)
   template <typename F>
   void run(const ::benchmark::State& state, F&& f) {
-    marl::Scheduler scheduler;
-    scheduler.setWorkerThreadCount(numThreads(state));
+    marl::Scheduler::Config cfg;
+    cfg.setWorkerThreadCount(numThreads(state));
+
+    marl::Scheduler scheduler(cfg);
     scheduler.bind();
     f(numTasks(state));
     scheduler.unbind();

--- a/src/marl_test.h
+++ b/src/marl_test.h
@@ -54,9 +54,12 @@ class WithBoundScheduler : public testing::TestWithParam<SchedulerParams> {
 
     auto& params = GetParam();
 
-    auto scheduler = new marl::Scheduler(allocator);
+    marl::Scheduler::Config cfg;
+    cfg.setAllocator(allocator);
+    cfg.setWorkerThreadCount(params.numWorkerThreads);
+
+    auto scheduler = new marl::Scheduler(cfg);
     scheduler->bind();
-    scheduler->setWorkerThreadCount(params.numWorkerThreads);
   }
 
   void TearDown() override {


### PR DESCRIPTION
Replace the use of `marl::Scheduler::setWorkerThreadCount` from tests, benchmarks, examples and documentation.

Enable warnings when attempting to use these methods.

Issue: #139