### PR TITLE
Support specifying worker thread affinities

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -254,6 +254,7 @@ if(MARL_BUILD_TESTS)
         ${MARL_SRC_DIR}/parallelize_test.cpp
         ${MARL_SRC_DIR}/pool_test.cpp
         ${MARL_SRC_DIR}/scheduler_test.cpp
+        ${MARL_SRC_DIR}/thread_test.cpp
         ${MARL_SRC_DIR}/ticket_test.cpp
         ${MARL_SRC_DIR}/waitgroup_test.cpp
         ${MARL_GOOGLETEST_DIR}/googletest/src/gtest-all.cc

--- a/include/marl/containers.h
+++ b/include/marl/containers.h
@@ -62,8 +62,12 @@ class vector {
   inline void pop_back();
   inline T& front();
   inline T& back();
+  inline const T& front() const;
+  inline const T& back() const;
   inline T* begin();
   inline T* end();
+  inline const T* begin() const;
+  inline const T* end() const;
   inline T& operator[](size_t i);
   inline const T& operator[](size_t i) const;
   inline size_t size() const;
@@ -187,12 +191,34 @@ T& vector<T, BASE_CAPACITY>::back() {
 }
 
 template <typename T, int BASE_CAPACITY>
+const T& vector<T, BASE_CAPACITY>::front() const {
+  MARL_ASSERT(count > 0, "front() called on empty vector");
+  return reinterpret_cast<T*>(elements)[0];
+}
+
+template <typename T, int BASE_CAPACITY>
+const T& vector<T, BASE_CAPACITY>::back() const {
+  MARL_ASSERT(count > 0, "back() called on empty vector");
+  return reinterpret_cast<T*>(elements)[count - 1];
+}
+
+template <typename T, int BASE_CAPACITY>
 T* vector<T, BASE_CAPACITY>::begin() {
   return reinterpret_cast<T*>(elements);
 }
 
 template <typename T, int BASE_CAPACITY>
 T* vector<T, BASE_CAPACITY>::end() {
+  return reinterpret_cast<T*>(elements) + count;
+}
+
+template <typename T, int BASE_CAPACITY>
+const T* vector<T, BASE_CAPACITY>::begin() const {
+  return reinterpret_cast<T*>(elements);
+}
+
+template <typename T, int BASE_CAPACITY>
+const T* vector<T, BASE_CAPACITY>::end() const {
   return reinterpret_cast<T*>(elements) + count;
 }
 

--- a/include/marl/scheduler.h
+++ b/include/marl/scheduler.h
@@ -60,6 +60,7 @@ class Scheduler {
     struct WorkerThread {
       int count = 0;
       ThreadInitializer initializer;
+      std::shared_ptr<Thread::Affinity::Policy> affinityPolicy;
     };
     WorkerThread workerThread;
 
@@ -74,6 +75,8 @@ class Scheduler {
     inline Config& setAllocator(Allocator*);
     inline Config& setWorkerThreadCount(int);
     inline Config& setWorkerThreadInitializer(const ThreadInitializer&);
+    inline Config& setWorkerThreadAffinityPolicy(
+        const std::shared_ptr<Thread::Affinity::Policy>&);
   };
 
   // Constructor.
@@ -528,6 +531,12 @@ Scheduler::Config& Scheduler::Config::setWorkerThreadCount(int count) {
 Scheduler::Config& Scheduler::Config::setWorkerThreadInitializer(
     const ThreadInitializer& initializer) {
   workerThread.initializer = initializer;
+  return *this;
+}
+
+Scheduler::Config& Scheduler::Config::setWorkerThreadAffinityPolicy(
+    const std::shared_ptr<Thread::Affinity::Policy>& policy) {
+  workerThread.affinityPolicy = policy;
   return *this;
 }
 

--- a/src/memory.cpp
+++ b/src/memory.cpp
@@ -19,7 +19,7 @@
 
 #include <cstring>
 
-#if defined(__linux__) || defined(__FreeBSD__) ||  defined(__APPLE__)
+#if defined(__linux__) || defined(__FreeBSD__) || defined(__APPLE__)
 #include <sys/mman.h>
 #include <unistd.h>
 namespace {

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -18,6 +18,9 @@
 #include "marl/defer.h"
 #include "marl/trace.h"
 
+#include <algorithm>  // std::sort
+#include <unordered_set>
+
 #include <cstdarg>
 #include <cstdio>
 
@@ -25,7 +28,9 @@
 #define WIN32_LEAN_AND_MEAN 1
 #include <windows.h>
 #include <cstdlib>  // mbstowcs
+#include <limits>   // std::numeric_limits
 #include <vector>
+#undef max
 #elif defined(__APPLE__)
 #include <mach/thread_act.h>
 #include <pthread.h>
@@ -42,10 +47,27 @@
 #include <thread>
 #endif
 
+namespace {
+
+struct CoreHasher {
+  inline uint64_t operator()(const marl::Thread::Core& core) const {
+    return core.pthread.index;
+  }
+};
+
+}  // anonymous namespace
+
 namespace marl {
 
 #if defined(_WIN32)
+static constexpr size_t MaxCoreCount =
+    std::numeric_limits<decltype(Thread::Core::windows.index)>::max() + 1ULL;
+static constexpr size_t MaxGroupCount =
+    std::numeric_limits<decltype(Thread::Core::windows.group)>::max() + 1ULL;
+static_assert(sizeof(KAFFINITY) * 8ULL <= MaxCoreCount,
+              "Thread::Core::windows.index is too small");
 
+namespace {
 #define CHECK_WIN32(expr)                                    \
   do {                                                       \
     auto res = expr;                                         \
@@ -53,8 +75,6 @@ namespace marl {
     MARL_ASSERT(res == TRUE, #expr " failed with error: %d", \
                 (int)GetLastError());                        \
   } while (false)
-
-namespace {
 
 struct ProcessorGroup {
   unsigned int count;  // number of logical processors in this group.
@@ -75,6 +95,7 @@ const std::vector<ProcessorGroup>& getProcessorGroups() {
           auto const& groupInfo = info[i].Group.GroupInfo[groupIdx];
           out.emplace_back(ProcessorGroup{groupInfo.ActiveProcessorCount,
                                           groupInfo.ActiveProcessorMask});
+          MARL_ASSERT(out.size() <= MaxGroupCount, "Group index overflow");
         }
       }
     }
@@ -82,38 +103,169 @@ const std::vector<ProcessorGroup>& getProcessorGroups() {
   }();
   return groups;
 }
+}  // namespace
+#endif  // defined(_WIN32)
 
-bool getGroupAffinity(unsigned int index, GROUP_AFFINITY* groupAffinity) {
-  auto& groups = getProcessorGroups();
-  for (size_t groupIdx = 0; groupIdx < groups.size(); groupIdx++) {
-    auto& group = groups[groupIdx];
-    if (index < group.count) {
-      for (int i = 0; i < sizeof(group.affinity) * 8; i++) {
-        if (group.affinity & (1ULL << i)) {
-          if (index == 0) {
-            groupAffinity->Group = static_cast<WORD>(groupIdx);
-            // Use the whole group's affinity, as the OS is then able to shuffle
-            // threads around based on external demands. Pinning these to a
-            // single core can cause up to 20% performance loss in benchmarking.
-            groupAffinity->Mask = group.affinity;
-            return true;
-          }
-          index--;
-        }
-      }
-      return false;
-    } else {
-      index -= group.count;
-    }
+////////////////////////////////////////////////////////////////////////////////
+// Thread::Affinty
+////////////////////////////////////////////////////////////////////////////////
+
+Thread::Affinity::Affinity(Allocator* allocator) : cores(allocator) {}
+Thread::Affinity::Affinity(Affinity&& other) : cores(std::move(other.cores)) {}
+Thread::Affinity::Affinity(const Affinity& other, Allocator* allocator)
+    : cores(other.cores, allocator) {}
+
+Thread::Affinity::Affinity(std::initializer_list<Core> list,
+                           Allocator* allocator)
+    : cores(allocator) {
+  cores.reserve(list.size());
+  for (auto core : list) {
+    cores.push_back(core);
   }
-  return false;
 }
 
-}  // namespace
+Thread::Affinity Thread::Affinity::all(
+    Allocator* allocator /* = Allocator::Default */) {
+  Thread::Affinity affinity(allocator);
+
+#if defined(_WIN32)
+  decltype(Core::windows.group) groupIndex = 0;
+  for (auto group : getProcessorGroups()) {
+    Core core;
+    core.windows.group = static_cast<decltype(Core::windows.group)>(groupIndex);
+    for (unsigned int coreIdx = 0; coreIdx < group.count; coreIdx++) {
+      if ((group.affinity >> coreIdx) & 1) {
+        core.windows.index = static_cast<decltype(core.windows.index)>(coreIdx);
+        affinity.cores.emplace_back(std::move(core));
+      }
+    }
+    groupIndex++;
+  }
+#elif defined(__linux__)
+  auto thread = pthread_self();
+  cpu_set_t cpuset;
+  CPU_ZERO(&cpuset);
+  if (pthread_getaffinity_np(thread, sizeof(cpu_set_t), &cpuset) == 0) {
+    int count = CPU_COUNT(&cpuset);
+    for (int i = 0; i < count; i++) {
+      Core core;
+      core.pthread.index = static_cast<uint16_t>(i);
+      affinity.cores.emplace_back(std::move(core));
+    }
+  }
+#elif defined(__FreeBSD__)
+  auto thread = pthread_self();
+  cpuset_t cpuset;
+  CPU_ZERO(&cpuset);
+  if (pthread_getaffinity_np(thread, sizeof(cpuset_t), &cpuset) == 0) {
+    int count = CPU_COUNT(&cpuset);
+    for (int i = 0; i < count; i++) {
+      Core core;
+      core.pthread.index = static_cast<uint16_t>(i);
+      affinity.cores.emplace_back(std::move(core));
+    }
+  }
+#else
+  static_assert(!supported,
+                "marl::Thread::Affinity::supported is true, but "
+                "Thread::Affinity::all() is not implemented for this platform");
+#endif
+
+  return affinity;
+}
+
+std::shared_ptr<Thread::Affinity::Policy> Thread::Affinity::Policy::anyOf(
+    Affinity&& affinity,
+    Allocator* allocator /* = Allocator::Default */) {
+  struct Policy : public Thread::Affinity::Policy {
+    Affinity affinity;
+    Policy(Affinity&& affinity) : affinity(std::move(affinity)) {}
+
+    Affinity get(uint32_t threadId, Allocator* allocator) const override {
+#if defined(_WIN32)
+      auto count = affinity.count();
+      if (count == 0) {
+        return Affinity(affinity, allocator);
+      }
+      auto group = affinity[threadId % affinity.count()].windows.group;
+      Affinity out(allocator);
+      out.cores.reserve(count);
+      for (auto core : affinity.cores) {
+        if (core.windows.group == group) {
+          out.cores.push_back(core);
+        }
+      }
+      return out;
+#else
+      return Affinity(affinity, allocator);
+#endif
+    }
+  };
+
+  return allocator->make_shared<Policy>(std::move(affinity));
+}
+
+std::shared_ptr<Thread::Affinity::Policy> Thread::Affinity::Policy::oneOf(
+    Affinity&& affinity,
+    Allocator* allocator /* = Allocator::Default */) {
+  struct Policy : public Thread::Affinity::Policy {
+    Affinity affinity;
+    Policy(Affinity&& affinity) : affinity(std::move(affinity)) {}
+
+    Affinity get(uint32_t threadId, Allocator* allocator) const override {
+      auto count = affinity.count();
+      if (count == 0) {
+        return Affinity(affinity, allocator);
+      }
+      return Affinity({affinity[threadId % affinity.count()]}, allocator);
+    }
+  };
+
+  return allocator->make_shared<Policy>(std::move(affinity));
+}
+
+size_t Thread::Affinity::count() const {
+  return cores.size();
+}
+
+Thread::Core Thread::Affinity::operator[](size_t index) const {
+  return cores[index];
+}
+
+Thread::Affinity& Thread::Affinity::add(const Thread::Affinity& other) {
+  std::unordered_set<Core, CoreHasher> set;
+  for (auto core : cores) {
+    set.emplace(core);
+  }
+  for (auto core : other.cores) {
+    if (set.count(core) == 0) {
+      cores.push_back(core);
+    }
+  }
+  std::sort(cores.begin(), cores.end());
+  return *this;
+}
+
+Thread::Affinity& Thread::Affinity::remove(const Thread::Affinity& other) {
+  std::unordered_set<Core, CoreHasher> set;
+  for (auto core : other.cores) {
+    set.emplace(core);
+  }
+  for (size_t i = 0; i < cores.size(); i++) {
+    if (set.count(cores[i]) != 0) {
+      cores[i] = cores.back();
+      cores.resize(cores.size() - 1);
+    }
+  }
+  std::sort(cores.begin(), cores.end());
+  return *this;
+}
+
+#if defined(_WIN32)
 
 class Thread::Impl {
  public:
-  Impl(const Func& func) : func(func) {}
+  Impl(Func&& func) : func(std::move(func)) {}
   static DWORD WINAPI run(void* self) {
     reinterpret_cast<Impl*>(self)->func();
     return 0;
@@ -123,7 +275,7 @@ class Thread::Impl {
   HANDLE handle;
 };
 
-Thread::Thread(unsigned int logicalCpu, const Func& func) {
+Thread::Thread(Affinity&& affinity, Func&& func) {
   SIZE_T size = 0;
   InitializeProcThreadAttributeList(nullptr, 1, 0, &size);
   MARL_ASSERT(size > 0,
@@ -136,13 +288,22 @@ Thread::Thread(unsigned int logicalCpu, const Func& func) {
   defer(DeleteProcThreadAttributeList(attributes));
 
   GROUP_AFFINITY groupAffinity = {};
-  if (getGroupAffinity(logicalCpu, &groupAffinity)) {
+
+  auto count = affinity.count();
+  if (count > 0) {
+    groupAffinity.Group = affinity[0].windows.group;
+    for (size_t i = 0; i < count; i++) {
+      auto core = affinity[i];
+      MARL_ASSERT(groupAffinity.Group == core.windows.group,
+                  "Cannot create thread that uses multiple affinity groups");
+      groupAffinity.Mask |= (1ULL << core.windows.index);
+    }
     CHECK_WIN32(UpdateProcThreadAttribute(
         attributes, 0, PROC_THREAD_ATTRIBUTE_GROUP_AFFINITY, &groupAffinity,
         sizeof(groupAffinity), nullptr, nullptr));
   }
 
-  impl = new Impl(func);
+  impl = new Impl(std::move(func));
   impl->handle = CreateRemoteThreadEx(GetCurrentProcess(), nullptr, 0,
                                       &Impl::run, impl, 0, attributes, nullptr);
 }
@@ -191,13 +352,47 @@ unsigned int Thread::numLogicalCPUs() {
 
 class Thread::Impl {
  public:
-  template <typename F>
-  Impl(F&& func) : thread(func) {}
+  Impl(Affinity&& affinity, Thread::Func&& f)
+      : affinity(std::move(affinity)), func(std::move(f)), thread([this] {
+          setAffinity();
+          func();
+        }) {}
+
+  Affinity affinity;
+  Func func;
   std::thread thread;
+
+  void setAffinity() {
+    auto count = affinity.count();
+    if (count == 0) {
+      return;
+    }
+
+#if defined(__linux__)
+    cpu_set_t cpuset;
+    CPU_ZERO(&cpuset);
+    for (size_t i = 0; i < count; i++) {
+      CPU_SET(affinity[i].pthread.index, &cpuset);
+    }
+    auto thread = pthread_self();
+    pthread_setaffinity_np(thread, sizeof(cpu_set_t), &cpuset);
+#elif defined(__FreeBSD__)
+    cpuset_t cpuset;
+    CPU_ZERO(&cpuset);
+    for (size_t i = 0; i < count; i++) {
+      CPU_SET(affinity[i].pthread.index, &cpuset);
+    }
+    auto thread = pthread_self();
+    pthread_setaffinity_np(thread, sizeof(cpuset_t), &cpuset);
+#else
+    MARL_ASSERT(!marl::Thread::Affinity::supported,
+                "Attempting to use thread affinity on a unsupported platform");
+#endif
+  }
 };
 
-Thread::Thread(unsigned int /* logicalCpu */, const Func& func)
-    : impl(new Thread::Impl(func)) {}
+Thread::Thread(Affinity&& affinity, Func&& func)
+    : impl(new Thread::Impl(std::move(affinity), std::move(func))) {}
 
 Thread::~Thread() {
   delete impl;

--- a/src/thread_test.cpp
+++ b/src/thread_test.cpp
@@ -1,0 +1,123 @@
+// Copyright 2019 The Marl Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "marl_test.h"
+
+#include "marl/thread.h"
+
+namespace {
+
+marl::Thread::Core core(int idx) {
+  marl::Thread::Core c;
+  c.pthread.index = static_cast<uint16_t>(idx);
+  return c;
+}
+
+}  // anonymous namespace
+
+TEST_F(WithoutBoundScheduler, ThreadAffinityCount) {
+  auto affinity = marl::Thread::Affinity(
+      {
+          core(10),
+          core(20),
+          core(30),
+          core(40),
+      },
+      allocator);
+  EXPECT_EQ(affinity.count(), 4U);
+}
+
+TEST_F(WithoutBoundScheduler, ThreadAdd) {
+  auto affinity = marl::Thread::Affinity(
+      {
+          core(10),
+          core(20),
+          core(30),
+          core(40),
+      },
+      allocator);
+
+  affinity
+      .add(marl::Thread::Affinity(
+          {
+              core(25),
+              core(15),
+          },
+          allocator))
+      .add(marl::Thread::Affinity({core(35)}, allocator));
+
+  EXPECT_EQ(affinity.count(), 7U);
+  EXPECT_EQ(affinity[0], core(10));
+  EXPECT_EQ(affinity[1], core(15));
+  EXPECT_EQ(affinity[2], core(20));
+  EXPECT_EQ(affinity[3], core(25));
+  EXPECT_EQ(affinity[4], core(30));
+  EXPECT_EQ(affinity[5], core(35));
+  EXPECT_EQ(affinity[6], core(40));
+}
+
+TEST_F(WithoutBoundScheduler, ThreadRemove) {
+  auto affinity = marl::Thread::Affinity(
+      {
+          core(10),
+          core(20),
+          core(30),
+          core(40),
+      },
+      allocator);
+
+  affinity
+      .remove(marl::Thread::Affinity(
+          {
+              core(25),
+              core(20),
+          },
+          allocator))
+      .remove(marl::Thread::Affinity({core(40)}, allocator));
+
+  EXPECT_EQ(affinity.count(), 2U);
+  EXPECT_EQ(affinity[0], core(10));
+  EXPECT_EQ(affinity[1], core(30));
+}
+
+TEST_F(WithoutBoundScheduler, ThreadAffinityAllCountNonzero) {
+  auto affinity = marl::Thread::Affinity::all(allocator);
+  if (marl::Thread::Affinity::supported) {
+    EXPECT_NE(affinity.count(), 0U);
+  } else {
+    EXPECT_EQ(affinity.count(), 0U);
+  }
+}
+
+TEST_F(WithoutBoundScheduler, ThreadAffinityPolicyOneOf) {
+  auto all = marl::Thread::Affinity(
+      {
+          core(10),
+          core(20),
+          core(30),
+          core(40),
+      },
+      allocator);
+
+  auto policy =
+      marl::Thread::Affinity::Policy::oneOf(std::move(all), allocator);
+  EXPECT_EQ(policy->get(0, allocator).count(), 1U);
+  EXPECT_EQ(policy->get(0, allocator)[0].pthread.index, 10);
+  EXPECT_EQ(policy->get(1, allocator).count(), 1U);
+  EXPECT_EQ(policy->get(1, allocator)[0].pthread.index, 20);
+  EXPECT_EQ(policy->get(2, allocator).count(), 1U);
+  EXPECT_EQ(policy->get(2, allocator)[0].pthread.index, 30);
+  EXPECT_EQ(policy->get(3, allocator).count(), 1U);
+  EXPECT_EQ(policy->get(3, allocator)[0].pthread.index, 40);
+}


### PR DESCRIPTION
Add `Thread::Affinity` which describes the cores on which a thread can
execute.

Add `Thread::Affinity::Policy` which generates an `Affinity` for a
thread by identifier. `Policy` contains two helper functions that return
`Policy` implementations:
 * `anyOf()` returns a `Policy` that returns an Affinity for the
   available cores in the `Affinity` passed to the function.
 * `oneOf()` returns a `Policy` that returns an affinity with a single
   enabled core from the `Affinity` passed to the function.

Other `Policy`s can be implemented by the user.

Add a new `affinityPolicy` field to `Scheduler::Config` allowing the
user to specify the rules for assigning thread affinities to each
scheduler worker thread.

Affinities are currently only supported on windows, linux and freebsd.

Issue: #136