### PR TITLE
Benchmarks: Simplify tests further.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,7 +43,7 @@ option_if_not_defined(MARL_ASAN "Build marl with address sanitizer" OFF)
 option_if_not_defined(MARL_MSAN "Build marl with memory sanitizer" OFF)
 option_if_not_defined(MARL_TSAN "Build marl with thread sanitizer" OFF)
 option_if_not_defined(MARL_INSTALL "Create marl install target" OFF)
-option_if_not_defined(MARL_FULL_BENCHMARK "Benchmark all cores and a range of tasks" OFF)
+option_if_not_defined(MARL_FULL_BENCHMARK "Run benchmarks for [0 .. numLogicalCPUs] with no stepping" OFF)
 option_if_not_defined(MARL_DEBUG_ENABLED "Enable debug checks even in release builds" OFF)
 
 ###########################################################

--- a/src/event_bench.cpp
+++ b/src/event_bench.cpp
@@ -71,4 +71,4 @@ BENCHMARK_DEFINE_F(Schedule, EventBaton)(benchmark::State& state) {
     }
   });
 }
-BENCHMARK_REGISTER_F(Schedule, EventBaton)->Apply(Schedule::args<1000000>);
+BENCHMARK_REGISTER_F(Schedule, EventBaton)->Apply(Schedule::args<262144>);


### PR DESCRIPTION
Change the definition of `MARL_FULL_BENCHMARK` to only test `[0 .. numLogicalCPUs]` for `NumTasks`. I'm not sure there's that much value also testing a range of tasks (we have empty-task benchmarks for evaluating baseline costs), and it takes _way_ too long to run.

When `MARL_FULL_BENCHMARK` is not set, also include the upper `numLogicalCPUs` benchmark. There are plenty of non power-of-two cores out there, and stopping at the last POT within [0 - numLogicalCPUs] isn't ideal.

Change `EventBaton` to use `262144` tasks - this is what the old benchmark graphs actually used as it was the highest POT between [0 - 1000000].