### PR TITLE
Export DLL public symbols for building marl as dll

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -209,6 +209,12 @@ endfunction(marl_set_target_options)
 # marl
 if(MARL_BUILD_SHARED) # Can also be controlled by BUILD_SHARED_LIBS
     add_library(marl SHARED ${MARL_LIST})
+    if(MSVC)
+        target_compile_definitions(marl 
+            PRIVATE "MARL_BUILDING_DLL=1"
+            PUBLIC  "MARL_DLL=1"
+        )
+    endif()
 else()
     add_library(marl ${MARL_LIST})
 endif()

--- a/include/marl/debug.h
+++ b/include/marl/debug.h
@@ -15,6 +15,8 @@
 #ifndef marl_debug_h
 #define marl_debug_h
 
+#include "export.h"
+
 #if !defined(MARL_DEBUG_ENABLED)
 #if !defined(NDEBUG) || defined(DCHECK_ALWAYS_ON)
 #define MARL_DEBUG_ENABLED 1
@@ -25,8 +27,13 @@
 
 namespace marl {
 
+MARL_EXPORT
 void fatal(const char* msg, ...);
+
+MARL_EXPORT
 void warn(const char* msg, ...);
+
+MARL_EXPORT
 void assert_has_bound_scheduler(const char* feature);
 
 #if MARL_DEBUG_ENABLED

--- a/include/marl/export.h
+++ b/include/marl/export.h
@@ -1,0 +1,28 @@
+// Copyright 2020 The Marl Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef marl_export_h
+#define marl_export_h
+
+#ifdef MARL_DLL
+#if MARL_BUILDING_DLL
+#define MARL_EXPORT __declspec(dllexport)
+#else
+#define MARL_EXPORT __declspec(dllimport)
+#endif
+#else
+#define MARL_EXPORT
+#endif
+
+#endif  // marl_export_h

--- a/include/marl/memory.h
+++ b/include/marl/memory.h
@@ -16,6 +16,7 @@
 #define marl_memory_h
 
 #include "debug.h"
+#include "export.h"
 
 #include <stdint.h>
 
@@ -32,6 +33,7 @@ struct StlAllocator;
 
 // pageSize() returns the size in bytes of a virtual memory page for the host
 // system.
+MARL_EXPORT
 size_t pageSize();
 
 template <typename T>
@@ -87,6 +89,7 @@ class Allocator {
  public:
   // The default allocator. Initialized with an implementation that allocates
   // from the OS. Can be assigned a custom implementation.
+  MARL_EXPORT
   static Allocator* Default;
 
   // Deleter is a smart-pointer compatible deleter that can be used to delete

--- a/include/marl/scheduler.h
+++ b/include/marl/scheduler.h
@@ -18,6 +18,7 @@
 #include "containers.h"
 #include "debug.h"
 #include "deprecated.h"
+#include "export.h"
 #include "memory.h"
 #include "mutex.h"
 #include "task.h"
@@ -64,6 +65,7 @@ class Scheduler {
 
     // allCores() returns a Config with a worker thread for each of the logical
     // cpus available to the process.
+    MARL_EXPORT
     static Config allCores();
 
     // Fluent setters that return this Config so set calls can be chained.
@@ -75,33 +77,41 @@ class Scheduler {
   };
 
   // Constructor.
+  MARL_EXPORT
   Scheduler(const Config&);
 
   // Destructor.
   // Blocks until the scheduler is unbound from all threads before returning.
+  MARL_EXPORT
   ~Scheduler();
 
   // get() returns the scheduler bound to the current thread.
+  MARL_EXPORT
   static Scheduler* get();
 
   // bind() binds this scheduler to the current thread.
   // There must be no existing scheduler bound to the thread prior to calling.
+  MARL_EXPORT
   void bind();
 
   // unbind() unbinds the scheduler currently bound to the current thread.
   // There must be a existing scheduler bound to the thread prior to calling.
   // unbind() flushes any enqueued tasks on the single-threaded worker before
   // returning.
+  MARL_EXPORT
   static void unbind();
 
   // enqueue() queues the task for asynchronous execution.
+  MARL_EXPORT
   void enqueue(Task&& task);
 
   // config() returns the Config that was used to build the schededuler.
+  MARL_EXPORT
   const Config& config() const;
 
 #if MARL_ENABLE_DEPRECATED_SCHEDULER_GETTERS_SETTERS
   MARL_DEPRECATED(139, "use Scheduler::Scheduler(const Config&)")
+  MARL_EXPORT
   Scheduler(Allocator* allocator = Allocator::Default);
 
   // setThreadInitializer() sets the worker thread initializer function which
@@ -109,11 +119,13 @@ class Scheduler {
   // The initializer will only be called on newly created threads (call
   // setThreadInitializer() before setWorkerThreadCount()).
   MARL_DEPRECATED(139, "use Config::setWorkerThreadInitializer()")
+  MARL_EXPORT
   void setThreadInitializer(const std::function<void()>& init);
 
   // getThreadInitializer() returns the thread initializer function set by
   // setThreadInitializer().
   MARL_DEPRECATED(139, "use config().workerThread.initializer")
+  MARL_EXPORT
   std::function<void()> getThreadInitializer();
 
   // setWorkerThreadCount() adjusts the number of dedicated worker threads.
@@ -121,10 +133,12 @@ class Scheduler {
   // Note: Currently the number of threads cannot be adjusted once tasks
   // have been enqueued. This restriction may be lifted at a later time.
   MARL_DEPRECATED(139, "use Config::setWorkerThreadCount()")
+  MARL_EXPORT
   void setWorkerThreadCount(int count);
 
   // getWorkerThreadCount() returns the number of worker threads.
   MARL_DEPRECATED(139, "use config().workerThread.count")
+  MARL_EXPORT
   int getWorkerThreadCount();
 #endif  // MARL_ENABLE_DEPRECATED_SCHEDULER_GETTERS_SETTERS
 
@@ -141,6 +155,7 @@ class Scheduler {
    public:
     // current() returns the currently executing fiber, or nullptr if called
     // without a bound scheduler.
+    MARL_EXPORT
     static Fiber* current();
 
     // wait() suspends execution of this Fiber until the Fiber is woken up with
@@ -155,6 +170,7 @@ class Scheduler {
     // will be locked before wait() returns.
     // pred will be always be called with the lock held.
     // wait() must only be called on the currently executing fiber.
+    MARL_EXPORT
     void wait(marl::lock& lock, const Predicate& pred);
 
     // wait() suspends execution of this Fiber until the Fiber is woken up with
@@ -212,6 +228,7 @@ class Scheduler {
     // notify() reschedules the suspended Fiber for execution.
     // notify() is usually only called when the predicate for one or more wait()
     // calls will likely return true.
+    MARL_EXPORT
     void notify();
 
     // id is the thread-unique identifier of the Fiber.
@@ -349,12 +366,14 @@ class Scheduler {
     // wait() suspends execution of the current task until the predicate pred
     // returns true or the optional timeout is reached.
     // See Fiber::wait() for more information.
+    MARL_EXPORT
     bool wait(marl::lock& lock, const TimePoint* timeout, const Predicate& pred)
         EXCLUDES(work.mutex);
 
     // wait() suspends execution of the current task until the fiber is
     // notified, or the optional timeout is reached.
     // See Fiber::wait() for more information.
+    MARL_EXPORT
     bool wait(const TimePoint* timeout) EXCLUDES(work.mutex);
 
     // suspend() suspends the currenetly executing Fiber until the fiber is

--- a/include/marl/thread.h
+++ b/include/marl/thread.h
@@ -15,9 +15,10 @@
 #ifndef marl_thread_h
 #define marl_thread_h
 
-#include <functional>
-
 #include "containers.h"
+#include "export.h"
+
+#include <functional>
 
 namespace marl {
 
@@ -69,6 +70,7 @@ class Thread {
       // Windows requires that each thread is only associated with a
       // single affinity group, so the Policy's returned affinity will contain
       // cores all from the same group.
+      MARL_EXPORT
       static std::shared_ptr<Policy> anyOf(
           Affinity&& affinity,
           Allocator* allocator = Allocator::Default);
@@ -77,35 +79,48 @@ class Thread {
       // core from affinity. The single enabled core in the Policy's returned
       // affinity is:
       //      affinity[threadId % affinity.count()]
+      MARL_EXPORT
       static std::shared_ptr<Policy> oneOf(
           Affinity&& affinity,
           Allocator* allocator = Allocator::Default);
 
       // get() returns the thread Affinity for the for the given thread by id.
+      MARL_EXPORT
       virtual Affinity get(uint32_t threadId, Allocator* allocator) const = 0;
     };
 
+    MARL_EXPORT
     Affinity(Allocator*);
+
+    MARL_EXPORT
     Affinity(Affinity&&);
+
+    MARL_EXPORT
     Affinity(const Affinity&, Allocator* allocator);
 
     // all() returns an Affinity with all the cores available to the process.
+    MARL_EXPORT
     static Affinity all(Allocator* allocator = Allocator::Default);
 
+    MARL_EXPORT
     Affinity(std::initializer_list<Core>, Allocator* allocator);
 
     // count() returns the number of enabled cores in the affinity.
+    MARL_EXPORT
     size_t count() const;
 
     // operator[] returns the i'th enabled core from this affinity.
+    MARL_EXPORT
     Core operator[](size_t index) const;
 
     // add() adds the cores from the given affinity to this affinity.
     // This affinity is returned to allow for fluent calls.
+    MARL_EXPORT
     Affinity& add(const Affinity&);
 
     // remove() removes the cores from the given affinity from this affinity.
     // This affinity is returned to allow for fluent calls.
+    MARL_EXPORT
     Affinity& remove(const Affinity&);
 
    private:
@@ -114,24 +129,34 @@ class Thread {
     containers::vector<Core, 32> cores;
   };
 
+  MARL_EXPORT
   Thread() = default;
+
+  MARL_EXPORT
   Thread(Thread&&);
+
+  MARL_EXPORT
   Thread& operator=(Thread&&);
 
   // Start a new thread using the given affinity that calls func.
+  MARL_EXPORT
   Thread(Affinity&& affinity, Func&& func);
 
+  MARL_EXPORT
   ~Thread();
 
   // join() blocks until the thread completes.
+  MARL_EXPORT
   void join();
 
   // setName() sets the name of the currently executing thread for displaying
   // in a debugger.
+  MARL_EXPORT
   static void setName(const char* fmt, ...);
 
   // numLogicalCPUs() returns the number of available logical CPU cores for
   // the system.
+  MARL_EXPORT
   static unsigned int numLogicalCPUs();
 
  private:


### PR DESCRIPTION
This fixes the build when using the new `MARL_BUILD_SHARED` flag for Windows.