### PR TITLE
Fix Android build

### DIFF
--- a/include/marl/thread.h
+++ b/include/marl/thread.h
@@ -51,7 +51,8 @@ class Thread {
   struct Affinity {
     // supported is true if marl supports controlling thread affinity for this
     // platform.
-#if defined(_WIN32) || defined(__linux__) || defined(__FreeBSD__)
+#if defined(_WIN32) || (defined(__linux__) && !defined(__ANDROID__)) || \
+    defined(__FreeBSD__)
     static constexpr bool supported = true;
 #else
     static constexpr bool supported = false;

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -145,7 +145,7 @@ Thread::Affinity Thread::Affinity::all(
       }
     }
   }
-#elif defined(__linux__)
+#elif defined(__linux__) && !defined(__ANDROID__)
   auto thread = pthread_self();
   cpu_set_t cpuset;
   CPU_ZERO(&cpuset);
@@ -374,7 +374,7 @@ class Thread::Impl {
       return;
     }
 
-#if defined(__linux__)
+#if defined(__linux__) && !defined(__ANDROID__)
     cpu_set_t cpuset;
     CPU_ZERO(&cpuset);
     for (size_t i = 0; i < count; i++) {


### PR DESCRIPTION
For the NDK `__linux__` is defined, but the affinity functions do not have the same names.

Disable these code paths for `__ANDROID__` builds.