### PR TITLE
Add missing <vector> include

### DIFF
--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -29,6 +29,7 @@
 #include <array>
 #include <cstdlib>  // mbstowcs
 #include <limits>   // std::numeric_limits
+#include <vector>
 #undef max
 #elif defined(__APPLE__)
 #include <mach/thread_act.h>


### PR DESCRIPTION
Build fails on windows + clang.