### PR TITLE
CMake: Use -fvisibility=hidden by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -210,13 +210,19 @@ endfunction(marl_set_target_options)
 if(MARL_BUILD_SHARED) # Can also be controlled by BUILD_SHARED_LIBS
     add_library(marl SHARED ${MARL_LIST})
     if(MSVC)
-        target_compile_definitions(marl 
+        target_compile_definitions(marl
             PRIVATE "MARL_BUILDING_DLL=1"
             PUBLIC  "MARL_DLL=1"
         )
     endif()
 else()
     add_library(marl ${MARL_LIST})
+endif()
+
+
+if(NOT MSVC)
+    # Public API symbols are made visible with the MARL_EXPORT annotation.
+    target_compile_options(marl PRIVATE "-fvisibility=hidden")
 endif()
 
 set_target_properties(marl PROPERTIES

--- a/include/marl/export.h
+++ b/include/marl/export.h
@@ -16,13 +16,21 @@
 #define marl_export_h
 
 #ifdef MARL_DLL
+
 #if MARL_BUILDING_DLL
 #define MARL_EXPORT __declspec(dllexport)
 #else
 #define MARL_EXPORT __declspec(dllimport)
 #endif
+
+#else  // #ifdef MARL_DLL
+
+#if __GNUC__ >= 4
+#define MARL_EXPORT __attribute__((visibility("default")))
 #else
 #define MARL_EXPORT
 #endif
+
+#endif  //
 
 #endif  // marl_export_h

--- a/src/osfiber_aarch64.c
+++ b/src/osfiber_aarch64.c
@@ -16,10 +16,14 @@
 
 #include "osfiber_asm_aarch64.h"
 
+#include "marl/export.h"
+
+MARL_EXPORT
 void marl_fiber_trampoline(void (*target)(void*), void* arg) {
   target(arg);
 }
 
+MARL_EXPORT
 void marl_fiber_set_target(struct marl_fiber_context* ctx,
                            void* stack,
                            uint32_t stack_size,

--- a/src/osfiber_arm.c
+++ b/src/osfiber_arm.c
@@ -16,10 +16,14 @@
 
 #include "osfiber_asm_arm.h"
 
+#include "marl/export.h"
+
+MARL_EXPORT
 void marl_fiber_trampoline(void (*target)(void*), void* arg) {
   target(arg);
 }
 
+MARL_EXPORT
 void marl_fiber_set_target(struct marl_fiber_context* ctx,
                            void* stack,
                            uint32_t stack_size,

--- a/src/osfiber_asm.h
+++ b/src/osfiber_asm.h
@@ -38,6 +38,7 @@
 #error "Unsupported target"
 #endif
 
+#include "marl/export.h"
 #include "marl/memory.h"
 
 #include <functional>
@@ -45,11 +46,13 @@
 
 extern "C" {
 
+MARL_EXPORT
 extern void marl_fiber_set_target(marl_fiber_context*,
                                   void* stack,
                                   uint32_t stack_size,
                                   void (*target)(void*),
                                   void* arg);
+MARL_EXPORT
 extern void marl_fiber_swap(marl_fiber_context* from,
                             const marl_fiber_context* to);
 

--- a/src/osfiber_mips64.c
+++ b/src/osfiber_mips64.c
@@ -16,10 +16,14 @@
 
 #include "osfiber_asm_mips64.h"
 
+#include "marl/export.h"
+
+MARL_EXPORT
 void marl_fiber_trampoline(void (*target)(void*), void* arg) {
   target(arg);
 }
 
+MARL_EXPORT
 void marl_fiber_set_target(struct marl_fiber_context* ctx,
                            void* stack,
                            uint32_t stack_size,
@@ -32,4 +36,4 @@ void marl_fiber_set_target(struct marl_fiber_context* ctx,
   ctx->sp = ((uintptr_t)stack_top) & ~(uintptr_t)15;
 }
 
-#endif // defined(__mips__) && _MIPS_SIM == _ABI64
+#endif  // defined(__mips__) && _MIPS_SIM == _ABI64

--- a/src/osfiber_ppc64.c
+++ b/src/osfiber_ppc64.c
@@ -16,10 +16,14 @@
 
 #include "osfiber_asm_ppc64.h"
 
+#include "marl/export.h"
+
+MARL_EXPORT
 void marl_fiber_trampoline(void (*target)(void*), void* arg) {
   target(arg);
 }
 
+MARL_EXPORT
 void marl_fiber_set_target(struct marl_fiber_context* ctx,
                            void* stack,
                            uint32_t stack_size,

--- a/src/osfiber_x64.c
+++ b/src/osfiber_x64.c
@@ -16,10 +16,14 @@
 
 #include "osfiber_asm_x64.h"
 
+#include "marl/export.h"
+
+MARL_EXPORT
 void marl_fiber_trampoline(void (*target)(void*), void* arg) {
   target(arg);
 }
 
+MARL_EXPORT
 void marl_fiber_set_target(struct marl_fiber_context* ctx,
                            void* stack,
                            uint32_t stack_size,

--- a/src/osfiber_x86.c
+++ b/src/osfiber_x86.c
@@ -16,10 +16,14 @@
 
 #include "osfiber_asm_x86.h"
 
+#include "marl/export.h"
+
+MARL_EXPORT
 void marl_fiber_trampoline(void (*target)(void*), void* arg) {
   target(arg);
 }
 
+MARL_EXPORT
 void marl_fiber_set_target(struct marl_fiber_context* ctx,
                            void* stack,
                            uint32_t stack_size,


### PR DESCRIPTION
... and make `MARL_EXPORT` make the public API visible.

Ensures that users of marl aren't depending on non-public API details, which is a requirement for sane semantic versioning.