### PR TITLE
Annotate all public API inlines with MARL_NO_EXPORT

### DIFF
--- a/include/marl/blockingcall.h
+++ b/include/marl/blockingcall.h
@@ -15,6 +15,7 @@
 #ifndef marl_blocking_call_h
 #define marl_blocking_call_h
 
+#include "export.h"
 #include "scheduler.h"
 #include "waitgroup.h"
 
@@ -29,7 +30,7 @@ template <typename RETURN_TYPE>
 class OnNewThread {
  public:
   template <typename F, typename... Args>
-  inline static RETURN_TYPE call(F&& f, Args&&... args) {
+  MARL_NO_EXPORT inline static RETURN_TYPE call(F&& f, Args&&... args) {
     RETURN_TYPE result;
     WaitGroup wg(1);
     auto scheduler = Scheduler::get();
@@ -55,7 +56,7 @@ template <>
 class OnNewThread<void> {
  public:
   template <typename F, typename... Args>
-  inline static void call(F&& f, Args&&... args) {
+  MARL_NO_EXPORT inline static void call(F&& f, Args&&... args) {
     WaitGroup wg(1);
     auto scheduler = Scheduler::get();
     auto thread = std::thread(
@@ -94,7 +95,8 @@ class OnNewThread<void> {
 //      });
 //  }
 template <typename F, typename... Args>
-auto inline blocking_call(F&& f, Args&&... args) -> decltype(f(args...)) {
+MARL_NO_EXPORT auto inline blocking_call(F&& f, Args&&... args)
+    -> decltype(f(args...)) {
   return detail::OnNewThread<decltype(f(args...))>::call(
       std::forward<F>(f), std::forward<Args>(args)...);
 }

--- a/include/marl/conditionvariable.h
+++ b/include/marl/conditionvariable.h
@@ -35,37 +35,40 @@ namespace marl {
 // thread will work on other tasks until the ConditionVariable is unblocked.
 class ConditionVariable {
  public:
-  inline ConditionVariable(Allocator* allocator = Allocator::Default);
+  MARL_NO_EXPORT inline ConditionVariable(
+      Allocator* allocator = Allocator::Default);
 
   // notify_one() notifies and potentially unblocks one waiting fiber or thread.
-  inline void notify_one();
+  MARL_NO_EXPORT inline void notify_one();
 
   // notify_all() notifies and potentially unblocks all waiting fibers and/or
   // threads.
-  inline void notify_all();
+  MARL_NO_EXPORT inline void notify_all();
 
   // wait() blocks the current fiber or thread until the predicate is satisfied
   // and the ConditionVariable is notified.
   template <typename Predicate>
-  inline void wait(marl::lock& lock, Predicate&& pred);
+  MARL_NO_EXPORT inline void wait(marl::lock& lock, Predicate&& pred);
 
   // wait_for() blocks the current fiber or thread until the predicate is
   // satisfied, and the ConditionVariable is notified, or the timeout has been
   // reached. Returns false if pred still evaluates to false after the timeout
   // has been reached, otherwise true.
   template <typename Rep, typename Period, typename Predicate>
-  bool wait_for(marl::lock& lock,
-                const std::chrono::duration<Rep, Period>& duration,
-                Predicate&& pred);
+  MARL_NO_EXPORT inline bool wait_for(
+      marl::lock& lock,
+      const std::chrono::duration<Rep, Period>& duration,
+      Predicate&& pred);
 
   // wait_until() blocks the current fiber or thread until the predicate is
   // satisfied, and the ConditionVariable is notified, or the timeout has been
   // reached. Returns false if pred still evaluates to false after the timeout
   // has been reached, otherwise true.
   template <typename Clock, typename Duration, typename Predicate>
-  bool wait_until(marl::lock& lock,
-                  const std::chrono::time_point<Clock, Duration>& timeout,
-                  Predicate&& pred);
+  MARL_NO_EXPORT inline bool wait_until(
+      marl::lock& lock,
+      const std::chrono::time_point<Clock, Duration>& timeout,
+      Predicate&& pred);
 
  private:
   ConditionVariable(const ConditionVariable&) = delete;

--- a/include/marl/containers.h
+++ b/include/marl/containers.h
@@ -58,7 +58,7 @@ using unordered_set = std::unordered_set<K, H, E, StlAllocator<K>>;
 
 // take() takes and returns the front value from the deque.
 template <typename T>
-inline T take(deque<T>& queue) {
+MARL_NO_EXPORT inline T take(deque<T>& queue) {
   auto out = std::move(queue.front());
   queue.pop_front();
   return out;
@@ -66,7 +66,7 @@ inline T take(deque<T>& queue) {
 
 // take() takes and returns the first value from the unordered_set.
 template <typename T, typename H, typename E>
-inline T take(unordered_set<T, H, E>& set) {
+MARL_NO_EXPORT inline T take(unordered_set<T, H, E>& set) {
   auto it = set.begin();
   auto out = std::move(*it);
   set.erase(it);
@@ -85,45 +85,47 @@ inline T take(unordered_set<T, H, E>& set) {
 template <typename T, int BASE_CAPACITY>
 class vector {
  public:
-  inline vector(Allocator* allocator = Allocator::Default);
+  MARL_NO_EXPORT inline vector(Allocator* allocator = Allocator::Default);
 
   template <int BASE_CAPACITY_2>
-  inline vector(const vector<T, BASE_CAPACITY_2>& other,
-                Allocator* allocator = Allocator::Default);
+  MARL_NO_EXPORT inline vector(const vector<T, BASE_CAPACITY_2>& other,
+                               Allocator* allocator = Allocator::Default);
 
   template <int BASE_CAPACITY_2>
-  inline vector(vector<T, BASE_CAPACITY_2>&& other,
-                Allocator* allocator = Allocator::Default);
+  MARL_NO_EXPORT inline vector(vector<T, BASE_CAPACITY_2>&& other,
+                               Allocator* allocator = Allocator::Default);
 
-  inline ~vector();
+  MARL_NO_EXPORT inline ~vector();
 
-  inline vector& operator=(const vector&);
-
-  template <int BASE_CAPACITY_2>
-  inline vector<T, BASE_CAPACITY>& operator=(const vector<T, BASE_CAPACITY_2>&);
+  MARL_NO_EXPORT inline vector& operator=(const vector&);
 
   template <int BASE_CAPACITY_2>
-  inline vector<T, BASE_CAPACITY>& operator=(vector<T, BASE_CAPACITY_2>&&);
+  MARL_NO_EXPORT inline vector<T, BASE_CAPACITY>& operator=(
+      const vector<T, BASE_CAPACITY_2>&);
 
-  inline void push_back(const T& el);
-  inline void emplace_back(T&& el);
-  inline void pop_back();
-  inline T& front();
-  inline T& back();
-  inline const T& front() const;
-  inline const T& back() const;
-  inline T* begin();
-  inline T* end();
-  inline const T* begin() const;
-  inline const T* end() const;
-  inline T& operator[](size_t i);
-  inline const T& operator[](size_t i) const;
-  inline size_t size() const;
-  inline size_t cap() const;
-  inline void resize(size_t n);
-  inline void reserve(size_t n);
-  inline T* data();
-  inline const T* data() const;
+  template <int BASE_CAPACITY_2>
+  MARL_NO_EXPORT inline vector<T, BASE_CAPACITY>& operator=(
+      vector<T, BASE_CAPACITY_2>&&);
+
+  MARL_NO_EXPORT inline void push_back(const T& el);
+  MARL_NO_EXPORT inline void emplace_back(T&& el);
+  MARL_NO_EXPORT inline void pop_back();
+  MARL_NO_EXPORT inline T& front();
+  MARL_NO_EXPORT inline T& back();
+  MARL_NO_EXPORT inline const T& front() const;
+  MARL_NO_EXPORT inline const T& back() const;
+  MARL_NO_EXPORT inline T* begin();
+  MARL_NO_EXPORT inline T* end();
+  MARL_NO_EXPORT inline const T* begin() const;
+  MARL_NO_EXPORT inline const T* end() const;
+  MARL_NO_EXPORT inline T& operator[](size_t i);
+  MARL_NO_EXPORT inline const T& operator[](size_t i) const;
+  MARL_NO_EXPORT inline size_t size() const;
+  MARL_NO_EXPORT inline size_t cap() const;
+  MARL_NO_EXPORT inline void resize(size_t n);
+  MARL_NO_EXPORT inline void reserve(size_t n);
+  MARL_NO_EXPORT inline T* data();
+  MARL_NO_EXPORT inline const T* data() const;
 
   Allocator* const allocator;
 
@@ -132,7 +134,7 @@ class vector {
 
   vector(const vector&) = delete;
 
-  inline void free();
+  MARL_NO_EXPORT inline void free();
 
   size_t count = 0;
   size_t capacity = BASE_CAPACITY;
@@ -366,28 +368,28 @@ class list {
  public:
   class iterator {
    public:
-    inline iterator(Entry*);
-    inline T* operator->();
-    inline T& operator*();
-    inline iterator& operator++();
-    inline bool operator==(const iterator&) const;
-    inline bool operator!=(const iterator&) const;
+    MARL_NO_EXPORT inline iterator(Entry*);
+    MARL_NO_EXPORT inline T* operator->();
+    MARL_NO_EXPORT inline T& operator*();
+    MARL_NO_EXPORT inline iterator& operator++();
+    MARL_NO_EXPORT inline bool operator==(const iterator&) const;
+    MARL_NO_EXPORT inline bool operator!=(const iterator&) const;
 
    private:
     friend list;
     Entry* entry;
   };
 
-  inline list(Allocator* allocator = Allocator::Default);
-  inline ~list();
+  MARL_NO_EXPORT inline list(Allocator* allocator = Allocator::Default);
+  MARL_NO_EXPORT inline ~list();
 
-  inline iterator begin();
-  inline iterator end();
-  inline size_t size() const;
+  MARL_NO_EXPORT inline iterator begin();
+  MARL_NO_EXPORT inline iterator end();
+  MARL_NO_EXPORT inline size_t size() const;
 
   template <typename... Args>
-  iterator emplace_front(Args&&... args);
-  inline void erase(iterator);
+  MARL_NO_EXPORT inline iterator emplace_front(Args&&... args);
+  MARL_NO_EXPORT inline void erase(iterator);
 
  private:
   // copy / move is currently unsupported.
@@ -401,10 +403,10 @@ class list {
     AllocationChain* next;
   };
 
-  void grow(size_t count);
+  MARL_NO_EXPORT inline void grow(size_t count);
 
-  static void unlink(Entry* entry, Entry*& list);
-  static void link(Entry* entry, Entry*& list);
+  MARL_NO_EXPORT static inline void unlink(Entry* entry, Entry*& list);
+  MARL_NO_EXPORT static inline void link(Entry* entry, Entry*& list);
 
   Allocator* const allocator;
   size_t size_ = 0;

--- a/include/marl/event.h
+++ b/include/marl/event.h
@@ -17,6 +17,7 @@
 
 #include "conditionvariable.h"
 #include "containers.h"
+#include "export.h"
 #include "memory.h"
 
 #include <chrono>
@@ -39,21 +40,21 @@ class Event {
     Manual
   };
 
-  inline Event(Mode mode = Mode::Auto,
-               bool initialState = false,
-               Allocator* allocator = Allocator::Default);
+  MARL_NO_EXPORT inline Event(Mode mode = Mode::Auto,
+                              bool initialState = false,
+                              Allocator* allocator = Allocator::Default);
 
   // signal() signals the event, possibly unblocking a call to wait().
-  inline void signal() const;
+  MARL_NO_EXPORT inline void signal() const;
 
   // clear() clears the signaled state.
-  inline void clear() const;
+  MARL_NO_EXPORT inline void clear() const;
 
   // wait() blocks until the event is signaled.
   // If the event was constructed with the Auto Mode, then only one
   // call to wait() will unblock before returning, upon which the signalled
   // state will be automatically cleared.
-  inline void wait() const;
+  MARL_NO_EXPORT inline void wait() const;
 
   // wait_for() blocks until the event is signaled, or the timeout has been
   // reached.
@@ -62,7 +63,7 @@ class Event {
   // then only one call to wait() will unblock before returning, upon which the
   // signalled state will be automatically cleared.
   template <typename Rep, typename Period>
-  inline bool wait_for(
+  MARL_NO_EXPORT inline bool wait_for(
       const std::chrono::duration<Rep, Period>& duration) const;
 
   // wait_until() blocks until the event is signaled, or the timeout has been
@@ -72,45 +73,49 @@ class Event {
   // then only one call to wait() will unblock before returning, upon which the
   // signalled state will be automatically cleared.
   template <typename Clock, typename Duration>
-  inline bool wait_until(
+  MARL_NO_EXPORT inline bool wait_until(
       const std::chrono::time_point<Clock, Duration>& timeout) const;
 
   // test() returns true if the event is signaled, otherwise false.
   // If the event is signalled and was constructed with the Auto Mode
   // then the signalled state will be automatically cleared upon returning.
-  inline bool test() const;
+  MARL_NO_EXPORT inline bool test() const;
 
   // isSignalled() returns true if the event is signaled, otherwise false.
   // Unlike test() the signal is not automatically cleared when the event was
   // constructed with the Auto Mode.
   // Note: No lock is held after bool() returns, so the event state may
   // immediately change after returning. Use with caution.
-  inline bool isSignalled() const;
+  MARL_NO_EXPORT inline bool isSignalled() const;
 
   // any returns an event that is automatically signalled whenever any of the
   // events in the list are signalled.
   template <typename Iterator>
-  inline static Event any(Mode mode,
-                          const Iterator& begin,
-                          const Iterator& end);
+  MARL_NO_EXPORT inline static Event any(Mode mode,
+                                         const Iterator& begin,
+                                         const Iterator& end);
 
   // any returns an event that is automatically signalled whenever any of the
   // events in the list are signalled.
   // This overload defaults to using the Auto mode.
   template <typename Iterator>
-  inline static Event any(const Iterator& begin, const Iterator& end);
+  MARL_NO_EXPORT inline static Event any(const Iterator& begin,
+                                         const Iterator& end);
 
  private:
   struct Shared {
-    inline Shared(Allocator* allocator, Mode mode, bool initialState);
-    inline void signal();
-    inline void wait();
+    MARL_NO_EXPORT inline Shared(Allocator* allocator,
+                                 Mode mode,
+                                 bool initialState);
+    MARL_NO_EXPORT inline void signal();
+    MARL_NO_EXPORT inline void wait();
 
     template <typename Rep, typename Period>
-    inline bool wait_for(const std::chrono::duration<Rep, Period>& duration);
+    MARL_NO_EXPORT inline bool wait_for(
+        const std::chrono::duration<Rep, Period>& duration);
 
     template <typename Clock, typename Duration>
-    inline bool wait_until(
+    MARL_NO_EXPORT inline bool wait_until(
         const std::chrono::time_point<Clock, Duration>& timeout);
 
     marl::mutex mutex;

--- a/include/marl/export.h
+++ b/include/marl/export.h
@@ -27,8 +27,15 @@
 
 #if __GNUC__ >= 4
 #define MARL_EXPORT __attribute__((visibility("default")))
-#else
+#define MARL_NO_EXPORT __attribute__((visibility("hidden")))
+#endif
+
+#ifndef MARL_EXPORT
 #define MARL_EXPORT
+#endif
+
+#ifndef MARL_NO_EXPORT
+#define MARL_NO_EXPORT
 #endif
 
 #endif  //

--- a/include/marl/finally.h
+++ b/include/marl/finally.h
@@ -24,6 +24,8 @@
 #ifndef marl_finally_h
 #define marl_finally_h
 
+#include "export.h"
+
 #include <functional>
 #include <memory>
 
@@ -42,10 +44,10 @@ class Finally {
 template <typename F>
 class FinallyImpl : public Finally {
  public:
-  inline FinallyImpl(const F& func);
-  inline FinallyImpl(F&& func);
-  inline FinallyImpl(FinallyImpl<F>&& other);
-  inline ~FinallyImpl();
+  MARL_NO_EXPORT inline FinallyImpl(const F& func);
+  MARL_NO_EXPORT inline FinallyImpl(F&& func);
+  MARL_NO_EXPORT inline FinallyImpl(FinallyImpl<F>&& other);
+  MARL_NO_EXPORT inline ~FinallyImpl();
 
  private:
   FinallyImpl(const FinallyImpl<F>& other) = delete;
@@ -75,12 +77,12 @@ FinallyImpl<F>::~FinallyImpl() {
 }
 
 template <typename F>
-inline FinallyImpl<F> make_finally(F&& f) {
+MARL_NO_EXPORT inline FinallyImpl<F> make_finally(F&& f) {
   return FinallyImpl<F>(std::move(f));
 }
 
 template <typename F>
-inline std::shared_ptr<Finally> make_shared_finally(F&& f) {
+MARL_NO_EXPORT inline std::shared_ptr<Finally> make_shared_finally(F&& f) {
   return std::make_shared<FinallyImpl<F>>(std::move(f));
 }
 

--- a/include/marl/memory.h
+++ b/include/marl/memory.h
@@ -37,7 +37,7 @@ MARL_EXPORT
 size_t pageSize();
 
 template <typename T>
-inline T alignUp(T val, T alignment) {
+MARL_NO_EXPORT inline T alignUp(T val, T alignment) {
   return alignment * ((val + alignment - 1) / alignment);
 }
 
@@ -89,18 +89,17 @@ class Allocator {
  public:
   // The default allocator. Initialized with an implementation that allocates
   // from the OS. Can be assigned a custom implementation.
-  MARL_EXPORT
-  static Allocator* Default;
+  MARL_EXPORT static Allocator* Default;
 
   // Deleter is a smart-pointer compatible deleter that can be used to delete
   // objects created by Allocator::create(). Deleter is used by the smart
   // pointers returned by make_shared() and make_unique().
-  struct Deleter {
-    inline Deleter();
-    inline Deleter(Allocator* allocator);
+  struct MARL_EXPORT Deleter {
+    MARL_NO_EXPORT inline Deleter();
+    MARL_NO_EXPORT inline Deleter(Allocator* allocator);
 
     template <typename T>
-    inline void operator()(T* object);
+    MARL_NO_EXPORT inline void operator()(T* object);
 
     Allocator* allocator = nullptr;
   };

--- a/include/marl/mutex.h
+++ b/include/marl/mutex.h
@@ -19,6 +19,7 @@
 #ifndef marl_mutex_h
 #define marl_mutex_h
 
+#include "export.h"
 #include "tsa.h"
 
 #include <condition_variable>
@@ -32,16 +33,18 @@ namespace marl {
 // as these require a std::unique_lock<> which are unsupported by the TSA.
 class CAPABILITY("mutex") mutex {
  public:
-  inline void lock() ACQUIRE() { _.lock(); }
+  MARL_NO_EXPORT inline void lock() ACQUIRE() { _.lock(); }
 
-  inline void unlock() RELEASE() { _.unlock(); }
+  MARL_NO_EXPORT inline void unlock() RELEASE() { _.unlock(); }
 
-  inline bool try_lock() TRY_ACQUIRE(true) { return _.try_lock(); }
+  MARL_NO_EXPORT inline bool try_lock() TRY_ACQUIRE(true) {
+    return _.try_lock();
+  }
 
   // wait_locked calls cv.wait() on this already locked mutex.
   template <typename Predicate>
-  inline void wait_locked(std::condition_variable& cv, Predicate&& p)
-      REQUIRES(this) {
+  MARL_NO_EXPORT inline void wait_locked(std::condition_variable& cv,
+                                         Predicate&& p) REQUIRES(this) {
     std::unique_lock<std::mutex> lock(_, std::adopt_lock);
     cv.wait(lock, std::forward<Predicate>(p));
     lock.release();  // Keep lock held.
@@ -49,9 +52,9 @@ class CAPABILITY("mutex") mutex {
 
   // wait_until_locked calls cv.wait() on this already locked mutex.
   template <typename Predicate, typename Time>
-  inline bool wait_until_locked(std::condition_variable& cv,
-                                Time&& time,
-                                Predicate&& p) REQUIRES(this) {
+  MARL_NO_EXPORT inline bool wait_until_locked(std::condition_variable& cv,
+                                               Time&& time,
+                                               Predicate&& p) REQUIRES(this) {
     std::unique_lock<std::mutex> lock(_, std::adopt_lock);
     auto res = cv.wait_until(lock, std::forward<Time>(time),
                              std::forward<Predicate>(p));

--- a/include/marl/parallelize.h
+++ b/include/marl/parallelize.h
@@ -22,10 +22,10 @@ namespace marl {
 
 namespace detail {
 
-inline void parallelizeChain(WaitGroup&) {}
+MARL_NO_EXPORT inline void parallelizeChain(WaitGroup&) {}
 
 template <typename F, typename... L>
-inline void parallelizeChain(WaitGroup& wg, F&& f, L&&... l) {
+MARL_NO_EXPORT inline void parallelizeChain(WaitGroup& wg, F&& f, L&&... l) {
   schedule([=] {
     f();
     wg.done();
@@ -49,7 +49,7 @@ inline void parallelizeChain(WaitGroup& wg, F&& f, L&&... l) {
 // pass the function that'll take the most time as the first argument. That way
 // you'll be more likely to avoid the cost of a fiber switch.
 template <typename F0, typename... FN>
-inline void parallelize(F0&& f0, FN&&... fn) {
+MARL_NO_EXPORT inline void parallelize(F0&& f0, FN&&... fn) {
   WaitGroup wg(sizeof...(FN));
   // Schedule all the functions in fn.
   detail::parallelizeChain(wg, std::forward<FN>(fn)...);

--- a/include/marl/pool.h
+++ b/include/marl/pool.h
@@ -53,17 +53,17 @@ class Pool {
   // item to the pool when the final Loan reference is dropped.
   class Loan {
    public:
-    inline Loan() = default;
-    inline Loan(Item*, const std::shared_ptr<Storage>&);
-    inline Loan(const Loan&);
-    inline Loan(Loan&&);
-    inline ~Loan();
-    inline Loan& operator=(const Loan&);
-    inline Loan& operator=(Loan&&);
-    inline T& operator*();
-    inline T* operator->() const;
-    inline T* get() const;
-    void reset();
+    MARL_NO_EXPORT inline Loan() = default;
+    MARL_NO_EXPORT inline Loan(Item*, const std::shared_ptr<Storage>&);
+    MARL_NO_EXPORT inline Loan(const Loan&);
+    MARL_NO_EXPORT inline Loan(Loan&&);
+    MARL_NO_EXPORT inline ~Loan();
+    MARL_NO_EXPORT inline Loan& operator=(const Loan&);
+    MARL_NO_EXPORT inline Loan& operator=(Loan&&);
+    MARL_NO_EXPORT inline T& operator*();
+    MARL_NO_EXPORT inline T* operator->() const;
+    MARL_NO_EXPORT inline T* get() const;
+    MARL_NO_EXPORT inline void reset();
 
    private:
     Item* item = nullptr;
@@ -83,13 +83,13 @@ class Pool {
   // The backing data of a single item in the pool.
   struct Item {
     // get() returns a pointer to the item's data.
-    inline T* get();
+    MARL_NO_EXPORT inline T* get();
 
     // construct() calls the constructor on the item's data.
-    inline void construct();
+    MARL_NO_EXPORT inline void construct();
 
     // destruct() calls the destructor on the item's data.
-    inline void destruct();
+    MARL_NO_EXPORT inline void destruct();
 
     using Data = typename aligned_storage<sizeof(T), alignof(T)>::type;
     Data data;
@@ -210,31 +210,31 @@ class BoundedPool : public Pool<T> {
   using Item = typename Pool<T>::Item;
   using Loan = typename Pool<T>::Loan;
 
-  inline BoundedPool(Allocator* allocator = Allocator::Default);
+  MARL_NO_EXPORT inline BoundedPool(Allocator* allocator = Allocator::Default);
 
   // borrow() borrows a single item from the pool, blocking until an item is
   // returned if the pool is empty.
-  inline Loan borrow() const;
+  MARL_NO_EXPORT inline Loan borrow() const;
 
   // borrow() borrows count items from the pool, blocking until there are at
   // least count items in the pool. The function f() is called with each
   // borrowed item.
   // F must be a function with the signature: void(T&&)
   template <typename F>
-  inline void borrow(size_t count, const F& f) const;
+  MARL_NO_EXPORT inline void borrow(size_t count, const F& f) const;
 
   // tryBorrow() attempts to borrow a single item from the pool without
   // blocking.
   // The boolean of the returned pair is true on success, or false if the pool
   // is empty.
-  inline std::pair<Loan, bool> tryBorrow() const;
+  MARL_NO_EXPORT inline std::pair<Loan, bool> tryBorrow() const;
 
  private:
   class Storage : public Pool<T>::Storage {
    public:
-    inline Storage(Allocator* allocator);
-    inline ~Storage();
-    inline void return_(Item*) override;
+    MARL_NO_EXPORT inline Storage(Allocator* allocator);
+    MARL_NO_EXPORT inline ~Storage();
+    MARL_NO_EXPORT inline void return_(Item*) override;
 
     Item items[N];
     marl::mutex mutex;
@@ -340,26 +340,27 @@ class UnboundedPool : public Pool<T> {
   using Item = typename Pool<T>::Item;
   using Loan = typename Pool<T>::Loan;
 
-  inline UnboundedPool(Allocator* allocator = Allocator::Default);
+  MARL_NO_EXPORT inline UnboundedPool(
+      Allocator* allocator = Allocator::Default);
 
   // borrow() borrows a single item from the pool, automatically allocating
   // more items if the pool is empty.
   // This function does not block.
-  inline Loan borrow() const;
+  MARL_NO_EXPORT inline Loan borrow() const;
 
   // borrow() borrows count items from the pool, calling the function f() with
   // each borrowed item.
   // F must be a function with the signature: void(T&&)
   // This function does not block.
   template <typename F>
-  inline void borrow(size_t n, const F& f) const;
+  MARL_NO_EXPORT inline void borrow(size_t n, const F& f) const;
 
  private:
   class Storage : public Pool<T>::Storage {
    public:
-    inline Storage(Allocator* allocator);
-    inline ~Storage();
-    inline void return_(Item*) override;
+    MARL_NO_EXPORT inline Storage(Allocator* allocator);
+    MARL_NO_EXPORT inline ~Storage();
+    MARL_NO_EXPORT inline void return_(Item*) override;
 
     Allocator* allocator;
     marl::mutex mutex;

--- a/include/marl/scheduler.h
+++ b/include/marl/scheduler.h
@@ -69,10 +69,11 @@ class Scheduler {
     static Config allCores();
 
     // Fluent setters that return this Config so set calls can be chained.
-    inline Config& setAllocator(Allocator*);
-    inline Config& setWorkerThreadCount(int);
-    inline Config& setWorkerThreadInitializer(const ThreadInitializer&);
-    inline Config& setWorkerThreadAffinityPolicy(
+    MARL_NO_EXPORT inline Config& setAllocator(Allocator*);
+    MARL_NO_EXPORT inline Config& setWorkerThreadCount(int);
+    MARL_NO_EXPORT inline Config& setWorkerThreadInitializer(
+        const ThreadInitializer&);
+    MARL_NO_EXPORT inline Config& setWorkerThreadAffinityPolicy(
         const std::shared_ptr<Thread::Affinity::Policy>&);
   };
 
@@ -188,9 +189,10 @@ class Scheduler {
     // pred will be always be called with the lock held.
     // wait() must only be called on the currently executing fiber.
     template <typename Clock, typename Duration>
-    inline bool wait(marl::lock& lock,
-                     const std::chrono::time_point<Clock, Duration>& timeout,
-                     const Predicate& pred);
+    MARL_NO_EXPORT inline bool wait(
+        marl::lock& lock,
+        const std::chrono::time_point<Clock, Duration>& timeout,
+        const Predicate& pred);
 
     // wait() suspends execution of this Fiber until the Fiber is woken up with
     // a call to notify().
@@ -206,7 +208,7 @@ class Scheduler {
     // wait() and notify() are made by the same thread.
     //
     // Use with extreme caution.
-    inline void wait();
+    MARL_NO_EXPORT inline void wait();
 
     // wait() suspends execution of this Fiber until the Fiber is woken up with
     // a call to notify(), or sometime after the timeout is reached.
@@ -223,7 +225,8 @@ class Scheduler {
     //
     // Use with extreme caution.
     template <typename Clock, typename Duration>
-    inline bool wait(const std::chrono::time_point<Clock, Duration>& timeout);
+    MARL_NO_EXPORT inline bool wait(
+        const std::chrono::time_point<Clock, Duration>& timeout);
 
     // notify() reschedules the suspended Fiber for execution.
     // notify() is usually only called when the predicate for one or more wait()

--- a/include/marl/task.h
+++ b/include/marl/task.h
@@ -34,24 +34,25 @@ class Task {
     SameThread = 1,
   };
 
-  inline Task();
-  inline Task(const Task&);
-  inline Task(Task&&);
-  inline Task(const Function& function, Flags flags = Flags::None);
-  inline Task(Function&& function, Flags flags = Flags::None);
-  inline Task& operator=(const Task&);
-  inline Task& operator=(Task&&);
-  inline Task& operator=(const Function&);
-  inline Task& operator=(Function&&);
+  MARL_NO_EXPORT inline Task();
+  MARL_NO_EXPORT inline Task(const Task&);
+  MARL_NO_EXPORT inline Task(Task&&);
+  MARL_NO_EXPORT inline Task(const Function& function,
+                             Flags flags = Flags::None);
+  MARL_NO_EXPORT inline Task(Function&& function, Flags flags = Flags::None);
+  MARL_NO_EXPORT inline Task& operator=(const Task&);
+  MARL_NO_EXPORT inline Task& operator=(Task&&);
+  MARL_NO_EXPORT inline Task& operator=(const Function&);
+  MARL_NO_EXPORT inline Task& operator=(Function&&);
 
   // operator bool() returns true if the Task has a valid function.
-  inline operator bool() const;
+  MARL_NO_EXPORT inline operator bool() const;
 
   // operator()() runs the task.
-  inline void operator()() const;
+  MARL_NO_EXPORT inline void operator()() const;
 
   // is() returns true if the Task was created with the given flag.
-  inline bool is(Flags flag) const;
+  MARL_NO_EXPORT inline bool is(Flags flag) const;
 
  private:
   Function function;

--- a/include/marl/thread.h
+++ b/include/marl/thread.h
@@ -43,8 +43,8 @@ class Thread {
     };
 
     // Comparison functions
-    inline bool operator==(const Core&) const;
-    inline bool operator<(const Core&) const;
+    MARL_NO_EXPORT inline bool operator==(const Core&) const;
+    MARL_NO_EXPORT inline bool operator<(const Core&) const;
   };
 
   // Affinity holds the affinity mask for a thread - a description of what cores
@@ -71,8 +71,7 @@ class Thread {
       // Windows requires that each thread is only associated with a
       // single affinity group, so the Policy's returned affinity will contain
       // cores all from the same group.
-      MARL_EXPORT
-      static std::shared_ptr<Policy> anyOf(
+      MARL_EXPORT static std::shared_ptr<Policy> anyOf(
           Affinity&& affinity,
           Allocator* allocator = Allocator::Default);
 
@@ -80,49 +79,39 @@ class Thread {
       // core from affinity. The single enabled core in the Policy's returned
       // affinity is:
       //      affinity[threadId % affinity.count()]
-      MARL_EXPORT
-      static std::shared_ptr<Policy> oneOf(
+      MARL_EXPORT static std::shared_ptr<Policy> oneOf(
           Affinity&& affinity,
           Allocator* allocator = Allocator::Default);
 
       // get() returns the thread Affinity for the for the given thread by id.
-      MARL_EXPORT
-      virtual Affinity get(uint32_t threadId, Allocator* allocator) const = 0;
+      MARL_EXPORT virtual Affinity get(uint32_t threadId,
+                                       Allocator* allocator) const = 0;
     };
 
-    MARL_EXPORT
-    Affinity(Allocator*);
+    MARL_EXPORT Affinity(Allocator*);
 
-    MARL_EXPORT
-    Affinity(Affinity&&);
+    MARL_EXPORT Affinity(Affinity&&);
 
-    MARL_EXPORT
-    Affinity(const Affinity&, Allocator* allocator);
+    MARL_EXPORT Affinity(const Affinity&, Allocator* allocator);
 
     // all() returns an Affinity with all the cores available to the process.
-    MARL_EXPORT
-    static Affinity all(Allocator* allocator = Allocator::Default);
+    MARL_EXPORT static Affinity all(Allocator* allocator = Allocator::Default);
 
-    MARL_EXPORT
-    Affinity(std::initializer_list<Core>, Allocator* allocator);
+    MARL_EXPORT Affinity(std::initializer_list<Core>, Allocator* allocator);
 
     // count() returns the number of enabled cores in the affinity.
-    MARL_EXPORT
-    size_t count() const;
+    MARL_EXPORT size_t count() const;
 
     // operator[] returns the i'th enabled core from this affinity.
-    MARL_EXPORT
-    Core operator[](size_t index) const;
+    MARL_EXPORT Core operator[](size_t index) const;
 
     // add() adds the cores from the given affinity to this affinity.
     // This affinity is returned to allow for fluent calls.
-    MARL_EXPORT
-    Affinity& add(const Affinity&);
+    MARL_EXPORT Affinity& add(const Affinity&);
 
     // remove() removes the cores from the given affinity from this affinity.
     // This affinity is returned to allow for fluent calls.
-    MARL_EXPORT
-    Affinity& remove(const Affinity&);
+    MARL_EXPORT Affinity& remove(const Affinity&);
 
    private:
     Affinity(const Affinity&) = delete;
@@ -130,35 +119,27 @@ class Thread {
     containers::vector<Core, 32> cores;
   };
 
-  MARL_EXPORT
-  Thread() = default;
+  MARL_EXPORT Thread() = default;
 
-  MARL_EXPORT
-  Thread(Thread&&);
+  MARL_EXPORT Thread(Thread&&);
 
-  MARL_EXPORT
-  Thread& operator=(Thread&&);
+  MARL_EXPORT Thread& operator=(Thread&&);
 
   // Start a new thread using the given affinity that calls func.
-  MARL_EXPORT
-  Thread(Affinity&& affinity, Func&& func);
+  MARL_EXPORT Thread(Affinity&& affinity, Func&& func);
 
-  MARL_EXPORT
-  ~Thread();
+  MARL_EXPORT ~Thread();
 
   // join() blocks until the thread completes.
-  MARL_EXPORT
-  void join();
+  MARL_EXPORT void join();
 
   // setName() sets the name of the currently executing thread for displaying
   // in a debugger.
-  MARL_EXPORT
-  static void setName(const char* fmt, ...);
+  MARL_EXPORT static void setName(const char* fmt, ...);
 
   // numLogicalCPUs() returns the number of available logical CPU cores for
   // the system.
-  MARL_EXPORT
-  static unsigned int numLogicalCPUs();
+  MARL_EXPORT static unsigned int numLogicalCPUs();
 
  private:
   Thread(const Thread&) = delete;

--- a/include/marl/ticket.h
+++ b/include/marl/ticket.h
@@ -68,45 +68,45 @@ class Ticket {
   class Queue {
    public:
     // take() returns a single ticket from the queue.
-    inline Ticket take();
+    MARL_NO_EXPORT inline Ticket take();
 
     // take() retrieves count tickets from the queue, calling f() with each
     // retrieved ticket.
     // F must be a function of the signature: void(Ticket&&)
     template <typename F>
-    inline void take(size_t count, const F& f);
+    MARL_NO_EXPORT inline void take(size_t count, const F& f);
 
    private:
     std::shared_ptr<Shared> shared = std::make_shared<Shared>();
     UnboundedPool<Record> pool;
   };
 
-  inline Ticket() = default;
-  inline Ticket(const Ticket& other) = default;
-  inline Ticket(Ticket&& other) = default;
-  inline Ticket& operator=(const Ticket& other) = default;
+  MARL_NO_EXPORT inline Ticket() = default;
+  MARL_NO_EXPORT inline Ticket(const Ticket& other) = default;
+  MARL_NO_EXPORT inline Ticket(Ticket&& other) = default;
+  MARL_NO_EXPORT inline Ticket& operator=(const Ticket& other) = default;
 
   // wait() blocks until the ticket is called.
-  inline void wait() const;
+  MARL_NO_EXPORT inline void wait() const;
 
   // done() marks the ticket as finished and calls the next ticket.
-  inline void done() const;
+  MARL_NO_EXPORT inline void done() const;
 
   // onCall() registers the function f to be invoked when this ticket is
   // called. If the ticket is already called prior to calling onCall(), then
   // f() will be executed immediately.
   // F must be a function of the OnCall signature.
   template <typename F>
-  inline void onCall(F&& f) const;
+  MARL_NO_EXPORT inline void onCall(F&& f) const;
 
  private:
   // Internal doubly-linked-list data structure. One per ticket instance.
   struct Record {
-    inline ~Record();
+    MARL_NO_EXPORT inline ~Record();
 
-    inline void done();
-    inline void callAndUnlock(marl::lock& lock);
-    inline void unlink();  // guarded by shared->mutex
+    MARL_NO_EXPORT inline void done();
+    MARL_NO_EXPORT inline void callAndUnlock(marl::lock& lock);
+    MARL_NO_EXPORT inline void unlink();  // guarded by shared->mutex
 
     ConditionVariable isCalledCondVar;
 
@@ -124,7 +124,7 @@ class Ticket {
     Record tail;
   };
 
-  inline Ticket(Loan<Record>&& record);
+  MARL_NO_EXPORT inline Ticket(Loan<Record>&& record);
 
   Loan<Record> record;
 };

--- a/include/marl/waitgroup.h
+++ b/include/marl/waitgroup.h
@@ -51,22 +51,22 @@ namespace marl {
 class WaitGroup {
  public:
   // Constructs the WaitGroup with the specified initial count.
-  inline WaitGroup(unsigned int initialCount = 0,
-                   Allocator* allocator = Allocator::Default);
+  MARL_NO_EXPORT inline WaitGroup(unsigned int initialCount = 0,
+                                  Allocator* allocator = Allocator::Default);
 
   // add() increments the internal counter by count.
-  inline void add(unsigned int count = 1) const;
+  MARL_NO_EXPORT inline void add(unsigned int count = 1) const;
 
   // done() decrements the internal counter by one.
   // Returns true if the internal count has reached zero.
-  inline bool done() const;
+  MARL_NO_EXPORT inline bool done() const;
 
   // wait() blocks until the WaitGroup counter reaches zero.
-  inline void wait() const;
+  MARL_NO_EXPORT inline void wait() const;
 
  private:
   struct Data {
-    inline Data(Allocator* allocator);
+    MARL_NO_EXPORT inline Data(Allocator* allocator);
 
     std::atomic<unsigned int> count = {0};
     ConditionVariable cv;

--- a/src/osfiber_asm.h
+++ b/src/osfiber_asm.h
@@ -67,22 +67,23 @@ class OSFiber {
 
   // createFiberFromCurrentThread() returns a fiber created from the current
   // thread.
-  static inline Allocator::unique_ptr<OSFiber> createFiberFromCurrentThread(
-      Allocator* allocator);
+  MARL_NO_EXPORT static inline Allocator::unique_ptr<OSFiber>
+  createFiberFromCurrentThread(Allocator* allocator);
 
   // createFiber() returns a new fiber with the given stack size that will
   // call func when switched to. func() must end by switching back to another
   // fiber, and must not return.
-  static inline Allocator::unique_ptr<OSFiber> createFiber(
+  MARL_NO_EXPORT static inline Allocator::unique_ptr<OSFiber> createFiber(
       Allocator* allocator,
       size_t stackSize,
       const std::function<void()>& func);
 
   // switchTo() immediately switches execution to the given fiber.
   // switchTo() must be called on the currently executing fiber.
-  inline void switchTo(OSFiber*);
+  MARL_NO_EXPORT inline void switchTo(OSFiber*);
 
  private:
+  MARL_NO_EXPORT
   static inline void run(OSFiber* self);
 
   Allocator* allocator;


### PR DESCRIPTION
Inline functions will default to a hidden visibility via `-fvisibility=hidden`, but this is a `PRIVATE` compile option, so external projects `#includ`ing marl's headers may default to visible for these inlines. This visibility mismatch can trigger linker warnings such as:

```
ld: warning: direct access in function 'std::__1::__shared_ptr_pointer<marl::Thread::Affinity::Policy::oneOf(marl::Thread::Affinity&&, marl::Allocator*)::Policy*, marl::Allocator::Deleter, std::__1::allocator<marl::Thread::Affinity::Policy::oneOf(marl::Thread::Affinity&&, marl::Allocator*)::Policy> >::__get_deleter(std::type_info const&) const' from file 'libmarl.a(thread.cpp.o)' to global weak symbol 'typeinfo name for marl::Allocator::Deleter' from file 'CMakeFiles/marl-unittests.dir/src/event_test.cpp.o' means the weak symbol cannot be overridden at runtime. This was likely caused by different translation units being compiled with different visibility settings.
```