### PR TITLE
Fix schedule() with function arguments

### DIFF
--- a/include/marl/scheduler.h
+++ b/include/marl/scheduler.h
@@ -614,7 +614,7 @@ inline void schedule(Function&& f, Args&&... args) {
   MARL_ASSERT_HAS_BOUND_SCHEDULER("marl::schedule");
   auto scheduler = Scheduler::get();
   scheduler->enqueue(
-      std::bind(std::forward<Function>(f), std::forward<Args>(args)...));
+      Task(std::bind(std::forward<Function>(f), std::forward<Args>(args)...)));
 }
 
 // schedule() schedules the function f to be asynchronously called using the

--- a/src/scheduler_test.cpp
+++ b/src/scheduler_test.cpp
@@ -94,6 +94,20 @@ TEST_P(WithBoundScheduler, DestructWithPendingFibers) {
   (new marl::Scheduler(marl::Scheduler::Config()))->bind();
 }
 
+TEST_P(WithBoundScheduler, ScheduleWithArgs) {
+  std::string got;
+  marl::WaitGroup wg(1);
+  marl::schedule(
+      [wg, &got](std::string s, int i, bool b) {
+        got = "s: '" + s + "', i: " + std::to_string(i) +
+              ", b: " + (b ? "true" : "false");
+        wg.done();
+      },
+      "a string", 42, true);
+  wg.wait();
+  ASSERT_EQ(got, "s: 'a string', i: 42, b: true");
+}
+
 TEST_P(WithBoundScheduler, FibersResumeOnSameThread) {
   marl::WaitGroup fence(1);
   marl::WaitGroup wg(1000);


### PR DESCRIPTION
The `std::bind` needs to be wrapped by a `Task` before being passed to `enqueue()`.

This got broken with 08a8201, but there were no tests.

Fixed, added tests.