### PR TITLE
Kokoro: Migrate to new Windows VM instance

### DIFF
--- a/kokoro/windows/msvc-2017-x64/cmake/presubmit.cfg
+++ b/kokoro/windows/msvc-2017-x64/cmake/presubmit.cfg
@@ -1,0 +1,19 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+
+# Location of the continuous bash script in Git.
+build_file: "marl/kokoro/windows/presubmit.bat"
+
+env_vars {
+  key: "BUILD_SYSTEM"
+  value: "cmake"
+}
+
+env_vars {
+  key: "BUILD_GENERATOR"
+  value: "Visual Studio 15 2017"
+}
+
+env_vars {
+  key: "BUILD_TARGET_ARCH"
+  value: "x64"
+}

--- a/kokoro/windows/msvc-2017-x86/cmake/presubmit.cfg
+++ b/kokoro/windows/msvc-2017-x86/cmake/presubmit.cfg
@@ -15,5 +15,5 @@ env_vars {
 
 env_vars {
   key: "BUILD_TARGET_ARCH"
-  value: "x86"
+  value: "Win32"
 }

--- a/kokoro/windows/msvc-2019-x64/cmake/presubmit.cfg
+++ b/kokoro/windows/msvc-2019-x64/cmake/presubmit.cfg
@@ -10,7 +10,7 @@ env_vars {
 
 env_vars {
   key: "BUILD_GENERATOR"
-  value: "Visual Studio 15 2017 Win64"
+  value: "Visual Studio 16 2019"
 }
 
 env_vars {

--- a/kokoro/windows/msvc-2019-x86/cmake/presubmit.cfg
+++ b/kokoro/windows/msvc-2019-x86/cmake/presubmit.cfg
@@ -1,0 +1,19 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+
+# Location of the continuous bash script in Git.
+build_file: "marl/kokoro/windows/presubmit.bat"
+
+env_vars {
+  key: "BUILD_SYSTEM"
+  value: "cmake"
+}
+
+env_vars {
+  key: "BUILD_GENERATOR"
+  value: "Visual Studio 16 2019"
+}
+
+env_vars {
+  key: "BUILD_TARGET_ARCH"
+  value: "Win32"
+}

--- a/kokoro/windows/presubmit.bat
+++ b/kokoro/windows/presubmit.bat
@@ -12,7 +12,6 @@ if !ERRORLEVEL! neq 0 exit !ERRORLEVEL!
 git submodule update --init
 if !ERRORLEVEL! neq 0 exit !ERRORLEVEL!
 
-SET MSBUILD="C:\Program Files (x86)\Microsoft Visual Studio\2017\BuildTools\MSBuild\15.0\Bin\MSBuild"
 SET CONFIG=Release
 
 mkdir %SRC%\build
@@ -20,15 +19,23 @@ cd %SRC%\build
 if !ERRORLEVEL! neq 0 exit !ERRORLEVEL!
 
 IF /I "%BUILD_SYSTEM%"=="cmake" (
-    cmake .. -G "%BUILD_GENERATOR%" "-DMARL_BUILD_TESTS=1" "-DMARL_BUILD_EXAMPLES=1" "-DMARL_BUILD_BENCHMARKS=1" "-DMARL_WARNINGS_AS_ERRORS=1" "-DMARL_DEBUG_ENABLED=1"
+    cmake .. ^
+        -G "%BUILD_GENERATOR%" ^
+        -A "%BUILD_TARGET_ARCH%" ^
+        "-DMARL_BUILD_TESTS=1" ^
+        "-DMARL_BUILD_EXAMPLES=1" ^
+        "-DMARL_BUILD_BENCHMARKS=1" ^
+        "-DMARL_WARNINGS_AS_ERRORS=1" ^
+        "-DMARL_DEBUG_ENABLED=1"
     if !ERRORLEVEL! neq 0 exit !ERRORLEVEL!
-    %MSBUILD% /p:Configuration=%CONFIG% Marl.sln
+    cmake --build . --config %CONFIG%
+
     if !ERRORLEVEL! neq 0 exit !ERRORLEVEL!
-    Release\marl-unittests.exe
+    %CONFIG%\marl-unittests.exe
     if !ERRORLEVEL! neq 0 exit !ERRORLEVEL!
-    Release\fractal.exe
+    %CONFIG%\fractal.exe
     if !ERRORLEVEL! neq 0 exit !ERRORLEVEL!
-    Release\primes.exe > nul
+    %CONFIG%\primes.exe > nul
     if !ERRORLEVEL! neq 0 exit !ERRORLEVEL!
 ) ELSE IF /I "%BUILD_SYSTEM%"=="bazel" (
     REM Fix up the MSYS environment.


### PR DESCRIPTION
Contains updated toolchains.

Also rename the bots to use the year - this is less confusing.

Add VS2019 variants.