### PR TITLE
Scheduler: Make the fiber stack size configurable

### DIFF
--- a/src/marl_test.h
+++ b/src/marl_test.h
@@ -57,6 +57,7 @@ class WithBoundScheduler : public testing::TestWithParam<SchedulerParams> {
     marl::Scheduler::Config cfg;
     cfg.setAllocator(allocator);
     cfg.setWorkerThreadCount(params.numWorkerThreads);
+    cfg.setFiberStackSize(0x10000);
 
     auto scheduler = new marl::Scheduler(cfg);
     scheduler->bind();

--- a/src/osfiber_windows.h
+++ b/src/osfiber_windows.h
@@ -64,7 +64,7 @@ OSFiber::~OSFiber() {
 Allocator::unique_ptr<OSFiber> OSFiber::createFiberFromCurrentThread(
     Allocator* allocator) {
   auto out = allocator->make_unique<OSFiber>();
-  out->fiber = ConvertThreadToFiberEx(nullptr,FIBER_FLAG_FLOAT_SWITCH);
+  out->fiber = ConvertThreadToFiberEx(nullptr, FIBER_FLAG_FLOAT_SWITCH);
   out->isFiberFromThread = true;
   MARL_ASSERT(out->fiber != nullptr,
               "ConvertThreadToFiberEx() failed with error 0x%x",
@@ -77,8 +77,10 @@ Allocator::unique_ptr<OSFiber> OSFiber::createFiber(
     size_t stackSize,
     const std::function<void()>& func) {
   auto out = allocator->make_unique<OSFiber>();
-  // stackSize is rounded up to the system's allocation granularity (typically 64 KB).
-  out->fiber = CreateFiberEx(stackSize - 1,stackSize,FIBER_FLAG_FLOAT_SWITCH,&OSFiber::run, out.get());
+  // stackSize is rounded up to the system's allocation granularity (typically
+  // 64 KB).
+  out->fiber = CreateFiberEx(stackSize - 1, stackSize, FIBER_FLAG_FLOAT_SWITCH,
+                             &OSFiber::run, out.get());
   out->target = func;
   MARL_ASSERT(out->fiber != nullptr, "CreateFiberEx() failed with error 0x%x",
               int(GetLastError()));

--- a/src/scheduler.cpp
+++ b/src/scheduler.cpp
@@ -702,7 +702,8 @@ void Scheduler::Worker::runUntilIdle() {
 Scheduler::Fiber* Scheduler::Worker::createWorkerFiber() {
   auto fiberId = static_cast<uint32_t>(workerFibers.size() + 1);
   DBG_LOG("%d: CREATE(%d)", (int)id, (int)fiberId);
-  auto fiber = Fiber::create(scheduler->cfg.allocator, fiberId, FiberStackSize,
+  auto fiber = Fiber::create(scheduler->cfg.allocator, fiberId,
+                             scheduler->cfg.fiberStackSize,
                              [&]() REQUIRES(work.mutex) { run(); });
   auto ptr = fiber.get();
   workerFibers.emplace_back(std::move(fiber));


### PR DESCRIPTION
Also clang-format `osfiber_windows.h` - there's no changes aside from style formatting here.

Fixes: #128