### PR TITLE
Kokoro: Add config for continuous + so builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -169,7 +169,7 @@ function(marl_set_target_options target)
 
     # Disable specific, pedantic warnings
     if(MSVC)
-        target_compile_options(${target} PRIVATE 
+        target_compile_options(${target} PRIVATE
             "-D_CRT_SECURE_NO_WARNINGS"
             "/wd4127" # conditional expression is constant
             "/wd4324" # structure was padded due to alignment specifier
@@ -208,7 +208,7 @@ endfunction(marl_set_target_options)
 ###########################################################
 
 # marl
-if(MARL_BUILD_SHARED) # Can also be controlled by BUILD_SHARED_LIBS
+if(MARL_BUILD_SHARED OR BUILD_SHARED_LIBS)
     add_library(marl SHARED ${MARL_LIST})
     if(MSVC)
         target_compile_definitions(marl

--- a/kokoro/macos/clang-x64/bazel/presubmit.cfg
+++ b/kokoro/macos/clang-x64/bazel/presubmit.cfg
@@ -1,6 +1,5 @@
 # Format: //devtools/kokoro/config/proto/build.proto
 
-# Location of the continuous bash script in Git.
 build_file: "marl/kokoro/macos/presubmit.sh"
 
 env_vars {

--- a/kokoro/macos/clang-x64/cmake/presubmit.cfg
+++ b/kokoro/macos/clang-x64/cmake/presubmit.cfg
@@ -1,6 +1,5 @@
 # Format: //devtools/kokoro/config/proto/build.proto
 
-# Location of the continuous bash script in Git.
 build_file: "marl/kokoro/macos/presubmit.sh"
 
 env_vars {

--- a/kokoro/ubuntu/android/arm64-v8a/cmake/presubmit.cfg
+++ b/kokoro/ubuntu/android/arm64-v8a/cmake/presubmit.cfg
@@ -1,6 +1,5 @@
 # Format: //devtools/kokoro/config/proto/build.proto
 
-# Location of the continuous bash script in Git.
 build_file: "marl/kokoro/ubuntu/presubmit.sh"
 
 env_vars {

--- a/kokoro/ubuntu/android/armeabi-v7a/cmake/presubmit.cfg
+++ b/kokoro/ubuntu/android/armeabi-v7a/cmake/presubmit.cfg
@@ -1,6 +1,5 @@
 # Format: //devtools/kokoro/config/proto/build.proto
 
-# Location of the continuous bash script in Git.
 build_file: "marl/kokoro/ubuntu/presubmit.sh"
 
 env_vars {

--- a/kokoro/ubuntu/android/x86_64/cmake/presubmit.cfg
+++ b/kokoro/ubuntu/android/x86_64/cmake/presubmit.cfg
@@ -1,6 +1,5 @@
 # Format: //devtools/kokoro/config/proto/build.proto
 
-# Location of the continuous bash script in Git.
 build_file: "marl/kokoro/ubuntu/presubmit.sh"
 
 env_vars {

--- a/kokoro/ubuntu/clang-x64/cmake/asan/presubmit.cfg
+++ b/kokoro/ubuntu/clang-x64/cmake/asan/presubmit.cfg
@@ -1,6 +1,5 @@
 # Format: //devtools/kokoro/config/proto/build.proto
 
-# Location of the continuous bash script in Git.
 build_file: "marl/kokoro/ubuntu/presubmit.sh"
 
 env_vars {

--- a/kokoro/ubuntu/clang-x64/cmake/presubmit.cfg
+++ b/kokoro/ubuntu/clang-x64/cmake/presubmit.cfg
@@ -1,6 +1,5 @@
 # Format: //devtools/kokoro/config/proto/build.proto
 
-# Location of the continuous bash script in Git.
 build_file: "marl/kokoro/ubuntu/presubmit.sh"
 
 env_vars {

--- a/kokoro/ubuntu/clang-x64/cmake/tsan/presubmit.cfg
+++ b/kokoro/ubuntu/clang-x64/cmake/tsan/presubmit.cfg
@@ -1,6 +1,5 @@
 # Format: //devtools/kokoro/config/proto/build.proto
 
-# Location of the continuous bash script in Git.
 build_file: "marl/kokoro/ubuntu/presubmit.sh"
 
 env_vars {

--- a/kokoro/ubuntu/clang-x86/cmake/presubmit.cfg
+++ b/kokoro/ubuntu/clang-x86/cmake/presubmit.cfg
@@ -1,6 +1,5 @@
 # Format: //devtools/kokoro/config/proto/build.proto
 
-# Location of the continuous bash script in Git.
 build_file: "marl/kokoro/ubuntu/presubmit.sh"
 
 env_vars {

--- a/kokoro/ubuntu/continuous.sh
+++ b/kokoro/ubuntu/continuous.sh
@@ -21,11 +21,13 @@ ROOT_DIR="$( cd "${SCRIPT_DIR}/../.." >/dev/null 2>&1 && pwd )"
 
 docker run --rm -i \
   --volume "${ROOT_DIR}:${ROOT_DIR}" \
+  --volume "${KOKORO_ARTIFACTS_DIR}:/mnt/artifacts" \
   --workdir "${ROOT_DIR}" \
   --env BUILD_SYSTEM=$BUILD_SYSTEM \
   --env BUILD_TOOLCHAIN=$BUILD_TOOLCHAIN \
   --env BUILD_TARGET_ARCH=$BUILD_TARGET_ARCH \
   --env BUILD_SHARED=${BUILD_SHARED:-0} \
   --env BUILD_SANITIZER=$BUILD_SANITIZER \
+  --env BUILD_ARTIFACTS="/mnt/artifacts" \
   --entrypoint "${SCRIPT_DIR}/docker.sh" \
   "gcr.io/shaderc-build/radial-build:latest"

--- a/kokoro/ubuntu/gcc-x64/bazel/presubmit.cfg
+++ b/kokoro/ubuntu/gcc-x64/bazel/presubmit.cfg
@@ -1,6 +1,5 @@
 # Format: //devtools/kokoro/config/proto/build.proto
 
-# Location of the continuous bash script in Git.
 build_file: "marl/kokoro/ubuntu/presubmit.sh"
 
 env_vars {

--- a/kokoro/ubuntu/gcc-x64/cmake/asan/presubmit.cfg
+++ b/kokoro/ubuntu/gcc-x64/cmake/asan/presubmit.cfg
@@ -1,6 +1,5 @@
 # Format: //devtools/kokoro/config/proto/build.proto
 
-# Location of the continuous bash script in Git.
 build_file: "marl/kokoro/ubuntu/presubmit.sh"
 
 env_vars {

--- a/kokoro/ubuntu/gcc-x64/cmake/presubmit.cfg
+++ b/kokoro/ubuntu/gcc-x64/cmake/presubmit.cfg
@@ -1,6 +1,5 @@
 # Format: //devtools/kokoro/config/proto/build.proto
 
-# Location of the continuous bash script in Git.
 build_file: "marl/kokoro/ubuntu/presubmit.sh"
 
 env_vars {

--- a/kokoro/ubuntu/gcc-x64/cmake/shared/continuous.cfg
+++ b/kokoro/ubuntu/gcc-x64/cmake/shared/continuous.cfg
@@ -1,6 +1,6 @@
 # Format: //devtools/kokoro/config/proto/build.proto
 
-build_file: "marl/kokoro/ubuntu/presubmit.sh"
+build_file: "marl/kokoro/ubuntu/continuous.sh"
 
 env_vars {
   key: "BUILD_SYSTEM"
@@ -18,6 +18,6 @@ env_vars {
 }
 
 env_vars {
-  key: "BUILD_SANITIZER"
-  value: "tsan"
+  key: "BUILD_SHARED"
+  value: "1"
 }

--- a/kokoro/ubuntu/gcc-x64/cmake/shared/presubmit.cfg
+++ b/kokoro/ubuntu/gcc-x64/cmake/shared/presubmit.cfg
@@ -18,6 +18,6 @@ env_vars {
 }
 
 env_vars {
-  key: "BUILD_SANITIZER"
-  value: "tsan"
+  key: "BUILD_SHARED"
+  value: "1"
 }

--- a/kokoro/ubuntu/gcc-x86/cmake/asan/presubmit.cfg
+++ b/kokoro/ubuntu/gcc-x86/cmake/asan/presubmit.cfg
@@ -1,6 +1,5 @@
 # Format: //devtools/kokoro/config/proto/build.proto
 
-# Location of the continuous bash script in Git.
 build_file: "marl/kokoro/ubuntu/presubmit.sh"
 
 env_vars {

--- a/kokoro/ubuntu/gcc-x86/cmake/presubmit.cfg
+++ b/kokoro/ubuntu/gcc-x86/cmake/presubmit.cfg
@@ -1,6 +1,5 @@
 # Format: //devtools/kokoro/config/proto/build.proto
 
-# Location of the continuous bash script in Git.
 build_file: "marl/kokoro/ubuntu/presubmit.sh"
 
 env_vars {

--- a/kokoro/windows/mingw-x64/bazel/presubmit.cfg
+++ b/kokoro/windows/mingw-x64/bazel/presubmit.cfg
@@ -1,6 +1,5 @@
 # Format: //devtools/kokoro/config/proto/build.proto
 
-# Location of the continuous bash script in Git.
 build_file: "marl/kokoro/windows/presubmit.bat"
 
 env_vars {

--- a/kokoro/windows/msvc-2017-x64/cmake/presubmit.cfg
+++ b/kokoro/windows/msvc-2017-x64/cmake/presubmit.cfg
@@ -1,6 +1,5 @@
 # Format: //devtools/kokoro/config/proto/build.proto
 
-# Location of the continuous bash script in Git.
 build_file: "marl/kokoro/windows/presubmit.bat"
 
 env_vars {

--- a/kokoro/windows/msvc-2017-x86/cmake/presubmit.cfg
+++ b/kokoro/windows/msvc-2017-x86/cmake/presubmit.cfg
@@ -1,6 +1,5 @@
 # Format: //devtools/kokoro/config/proto/build.proto
 
-# Location of the continuous bash script in Git.
 build_file: "marl/kokoro/windows/presubmit.bat"
 
 env_vars {

--- a/kokoro/windows/msvc-2019-x64/cmake/presubmit.cfg
+++ b/kokoro/windows/msvc-2019-x64/cmake/presubmit.cfg
@@ -1,6 +1,5 @@
 # Format: //devtools/kokoro/config/proto/build.proto
 
-# Location of the continuous bash script in Git.
 build_file: "marl/kokoro/windows/presubmit.bat"
 
 env_vars {

--- a/kokoro/windows/msvc-2019-x86/cmake/presubmit.cfg
+++ b/kokoro/windows/msvc-2019-x86/cmake/presubmit.cfg
@@ -1,6 +1,5 @@
 # Format: //devtools/kokoro/config/proto/build.proto
 
-# Location of the continuous bash script in Git.
 build_file: "marl/kokoro/windows/presubmit.bat"
 
 env_vars {


### PR DESCRIPTION
Add logic to copy build artifacts out to the `KOKORO_ARTIFACTS_DIR` for continuous builds.

Remove bogus copypasta `Location of the continuous bash script in Git` lines that are scattered through the *presubmit* configs. Clearly this was nonsense.

Add `BUILD_SHARED` kokoro build flag. Use this for the continuous builds as we'll more likely want to release `.so`s instead of `.a`s.

Fix `SCRIPT_DIR` & `ROOT_DIR` paths - these were a bit wonky.