### PR TITLE
Kokoro: Add define_artifacts action

### DIFF
--- a/kokoro/license-check/presubmit.sh
+++ b/kokoro/license-check/presubmit.sh
@@ -21,7 +21,6 @@ ROOT_DIR="$( cd "${SCRIPT_DIR}/../.." >/dev/null 2>&1 && pwd )"
 
 docker run --rm -i \
   --volume "${ROOT_DIR}:${ROOT_DIR}" \
-  --volume "${KOKORO_ARTIFACTS_DIR}:/mnt/artifacts" \
   --workdir "${ROOT_DIR}" \
   --entrypoint "${SCRIPT_DIR}/presubmit-docker.sh" \
   "gcr.io/shaderc-build/radial-build:latest"

--- a/kokoro/ubuntu/gcc-x64/cmake/shared/continuous.cfg
+++ b/kokoro/ubuntu/gcc-x64/cmake/shared/continuous.cfg
@@ -2,6 +2,12 @@
 
 build_file: "marl/kokoro/ubuntu/continuous.sh"
 
+action {
+  define_artifacts {
+    regex: ".*"
+  }
+}
+
 env_vars {
   key: "BUILD_SYSTEM"
   value: "cmake"


### PR DESCRIPTION
Needed to actually write the artifacts to the store.

Also remove the `KOKORO_ARTIFACTS_DIR` mount for `license-check` - no artifacts are produced for this job.