### PR TITLE
Fix instances of bugprone-move-forwarding-reference

### DIFF
--- a/include/marl/finally.h
+++ b/include/marl/finally.h
@@ -77,13 +77,13 @@ FinallyImpl<F>::~FinallyImpl() {
 }
 
 template <typename F>
-MARL_NO_EXPORT inline FinallyImpl<F> make_finally(F&& f) {
-  return FinallyImpl<F>(std::move(f));
+inline FinallyImpl<F> make_finally(F&& f) {
+  return FinallyImpl<F>(std::forward<F>(f));
 }
 
 template <typename F>
-MARL_NO_EXPORT inline std::shared_ptr<Finally> make_shared_finally(F&& f) {
-  return std::make_shared<FinallyImpl<F>>(std::move(f));
+inline std::shared_ptr<Finally> make_shared_finally(F&& f) {
+  return std::make_shared<FinallyImpl<F>>(std::forward<F>(f));
 }
 
 }  // namespace marl

--- a/include/marl/ticket.h
+++ b/include/marl/ticket.h
@@ -148,7 +148,7 @@ template <typename Function>
 void Ticket::onCall(Function&& f) const {
   marl::lock lock(record->shared->mutex);
   if (record->isCalled) {
-    marl::schedule(std::move(f));
+    marl::schedule(std::forward<Function>(f));
     return;
   }
   if (record->onCall) {
@@ -159,9 +159,10 @@ void Ticket::onCall(Function&& f) const {
       }
       OnCall a, b;
     };
-    record->onCall = std::move(Joined{std::move(record->onCall), std::move(f)});
+    record->onCall =
+        std::move(Joined{std::move(record->onCall), std::forward<Function>(f)});
   } else {
-    record->onCall = std::move(f);
+    record->onCall = std::forward<Function>(f);
   }
 }
 


### PR DESCRIPTION
Unless it's guaranteed that `std::forward` always turns into an rvalue ref, using `std::move(x)`, where `x`'s type is a universal reference, is generally unsafe.
`std::forward` is preferred for these cases.

This is upstreaming a fix made by George Burgess from https://swiftshader-review.googlesource.com/c/SwiftShader/+/48868.

Bug: https://bugs.chromium.org/p/chromium/issues/detail?id=1134310