### PR TITLE
ConditionVariable::notify_one should notify one waiter

### DIFF
--- a/include/marl/conditionvariable.h
+++ b/include/marl/conditionvariable.h
@@ -95,6 +95,7 @@ void ConditionVariable::notify_one() {
     marl::lock lock(mutex);
     if (waiting.size() > 0) {
       (*waiting.begin())->notify();  // Only wake one fiber.
+      return;
     }
   }
   if (numWaitingOnCondition > 0) {


### PR DESCRIPTION
A thread (without a bound `Scheduler`) and a fiber waiting on a
`ConditionVariable` might both be woken up with a call to
`ConditionVariable::notify_one()`. This revision modifies this behavior
so that exactly one fiber or thread is woken up, giving preference to
fibers.