### PR TITLE
Implement support for ppc64 ELFv1

### DIFF
--- a/src/osfiber_asm_ppc64.S
+++ b/src/osfiber_asm_ppc64.S
@@ -23,8 +23,20 @@
 .text
 .global marl_fiber_swap
 .align 4
+#if !defined(_CALL_ELF) || (_CALL_ELF != 2)
+.global .marl_fiber_swap
+.pushsection ".opd","aw"
+marl_fiber_swap:
+.quad .marl_fiber_swap
+.quad .TOC.@tocbase
+.quad 0
+.popsection
+.type .marl_fiber_swap,@function
+.marl_fiber_swap:
+#else
 .type marl_fiber_swap @function
 marl_fiber_swap:
+#endif
 
     // Store non-volatile registers
     std 1, MARL_REG_R1(3)

--- a/src/osfiber_asm_ppc64.h
+++ b/src/osfiber_asm_ppc64.h
@@ -123,11 +123,6 @@ struct marl_fiber_context {
   uintptr_t vmx[12 * 2];
 };
 
-// Only the ELFv2 ABI is supported for now.
-#if !defined(_CALL_ELF) || (_CALL_ELF != 2)
-#error "Only the ppc64 ELFv2 ABI is supported."
-#endif
-
 #ifdef __cplusplus
 #include <cstddef>
 static_assert(offsetof(marl_fiber_context, r1) == MARL_REG_R1,

--- a/src/osfiber_ppc64.c
+++ b/src/osfiber_ppc64.c
@@ -29,19 +29,29 @@ void marl_fiber_set_target(struct marl_fiber_context* ctx,
                            uint32_t stack_size,
                            void (*target)(void*),
                            void* arg) {
-  uintptr_t stack_top = (uintptr_t)((uint8_t*)(stack) + stack_size);
+  uintptr_t stack_top = (uintptr_t)((uint8_t*)(stack) + stack_size - sizeof(uintptr_t));
   if ((stack_top % 16) != 0) {
     stack_top -= (stack_top % 16);
   }
 
-  // Write a backchain and subtract a minimum stack frame size (32)
+  // Write a backchain and subtract a minimum stack frame size (32/48)
   *(uintptr_t*)stack_top = 0;
+#if !defined(_CALL_ELF) || (_CALL_ELF != 2)
+  stack_top -= 48;
+  *(uintptr_t*)stack_top = stack_top + 48;
+#else
   stack_top -= 32;
   *(uintptr_t*)stack_top = stack_top + 32;
+#endif
 
   // Load registers
   ctx->r1 = stack_top;
+#if !defined(_CALL_ELF) || (_CALL_ELF != 2)
+  ctx->lr = ((const uintptr_t *)marl_fiber_trampoline)[0];
+  ctx->r2 = ((const uintptr_t *)marl_fiber_trampoline)[1];
+#else
   ctx->lr = (uintptr_t)marl_fiber_trampoline;
+#endif
   ctx->r3 = (uintptr_t)target;
   ctx->r4 = (uintptr_t)arg;
 


### PR DESCRIPTION
This commit adds Yarn support for powerpc64 machines
using the ELFv1 ABI. The changes have been tested on
a POWER9 machine running in Big Endian mode and all
unit tests pass.

Note that I also fixed the bug that the call chain terminator could be written outside the stack.  This is not an ELFv1 specific fix; writing outside the stack is wrong on v2 as well.  😸 