### PR TITLE
Fix macOS arm64 cross compiling.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -167,6 +167,18 @@ if(NOT MSVC)
         ${MARL_SRC_DIR}/osfiber_x64.c
         ${MARL_SRC_DIR}/osfiber_x86.c
     )
+    # CMAKE_OSX_ARCHITECTURES settings aren't propagated to assembly files when
+    # building for Apple platforms (https://gitlab.kitware.com/cmake/cmake/-/issues/20771),
+    # we treat assembly files as C files to work around this bug.
+    set_source_files_properties(
+        ${MARL_SRC_DIR}/osfiber_asm_aarch64.S
+        ${MARL_SRC_DIR}/osfiber_asm_arm.S
+        ${MARL_SRC_DIR}/osfiber_asm_mips64.S
+        ${MARL_SRC_DIR}/osfiber_asm_ppc64.S
+        ${MARL_SRC_DIR}/osfiber_asm_x64.S
+        ${MARL_SRC_DIR}/osfiber_asm_x86.S
+        PROPERTIES LANGUAGE C
+    )
 endif(NOT MSVC)
 
 ###########################################################


### PR DESCRIPTION
CMAKE_OSX_ARCHITECTURES settings aren't propagated to assembly files
when building for Apple platforms (https://gitlab.kitware.com/cmake/cmake/-/issues/20771),
we treat assembly files as C files to work around this bug.

This change is copied from https://swiftshader-review.googlesource.com/c/SwiftShader/+/51890

Test: cmake .. -DCMAKE_OSX_ARCHITECTURES=arm64