### PR TITLE
Suppress MemorySanitizer false-positive

### DIFF
--- a/include/marl/sanitizers.h
+++ b/include/marl/sanitizers.h
@@ -78,4 +78,13 @@
 #define THREAD_SANITIZER_ONLY(x)
 #endif  // THREAD_SANITIZER_ENABLED
 
+// The CLANG_NO_SANITIZE_MEMORY macro suppresses MemorySanitizer checks for
+// use-of-uninitialized-data. It can be used to decorate functions with known
+// false positives.
+#ifdef __clang__
+#define CLANG_NO_SANITIZE_MEMORY __attribute__((no_sanitize_memory))
+#else
+#define CLANG_NO_SANITIZE_MEMORY
+#endif
+
 #endif  // marl_sanitizers_h

--- a/src/scheduler.cpp
+++ b/src/scheduler.cpp
@@ -234,6 +234,9 @@ Scheduler::Fiber::Fiber(Allocator::unique_ptr<OSFiber>&& impl, uint32_t id)
   MARL_ASSERT(worker != nullptr, "No Scheduler::Worker bound");
 }
 
+// TODO(chromium:1211047): Testing the static thread_local Worker::current for
+// null causes a MemorySantizer false positive.
+CLANG_NO_SANITIZE_MEMORY
 Scheduler::Fiber* Scheduler::Fiber::current() {
   auto worker = Worker::getCurrent();
   return worker != nullptr ? worker->getCurrentFiber() : nullptr;


### PR DESCRIPTION
Worker::current is a static thread_local which gets intialized to null,
which gets checked for in Scheduler::Fiber::current(). Unfortunately
MemorySanitizer does not observe the initialization when Marl is used
within a shared library, when the Linux dynamic loader is not
instrumented and its TLS initialization is not otherwise intercepted and
handled correctly.

This change decorates Scheduler::Fiber::current() with
__attribute__((no_sanitize_memory)) to suppress instrumenting it with
use-of-uninitialized-data checks.

A corresponding patch was made in SwiftShader at:
https://swiftshader-review.googlesource.com/c/SwiftShader/+/54610

Bug: chromium:1211047