### PR TITLE
Double the `fiberStackSize` for OSFiber tests

### DIFF
--- a/src/osfiber_test.cpp
+++ b/src/osfiber_test.cpp
@@ -18,7 +18,10 @@
 
 namespace {
 
-auto constexpr fiberStackSize = 8 * 1024;
+// A custom, small stack size for the fibers in these tests.
+// Note: Stack sizes less than 16KB may cause issues on some platforms.
+// See: https://github.com/google/marl/issues/201
+constexpr size_t fiberStackSize = 16 * 1024;
 
 }  // anonymous namespace
 


### PR DESCRIPTION
It appears that some platforms require at least 16KB.

Bug: #201