### PR TITLE
Add rv64 support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -160,10 +160,12 @@ if(NOT MSVC)
         ${MARL_SRC_DIR}/osfiber_asm_arm.S
         ${MARL_SRC_DIR}/osfiber_asm_mips64.S
         ${MARL_SRC_DIR}/osfiber_asm_ppc64.S
+        ${MARL_SRC_DIR}/osfiber_asm_rv64.S
         ${MARL_SRC_DIR}/osfiber_asm_x64.S
         ${MARL_SRC_DIR}/osfiber_asm_x86.S
         ${MARL_SRC_DIR}/osfiber_mips64.c
         ${MARL_SRC_DIR}/osfiber_ppc64.c
+        ${MARL_SRC_DIR}/osfiber_rv64.c
         ${MARL_SRC_DIR}/osfiber_x64.c
         ${MARL_SRC_DIR}/osfiber_x86.c
     )
@@ -236,6 +238,10 @@ function(marl_set_target_options target)
 
     if(MARL_DEBUG_ENABLED)
         target_compile_definitions(${target} PRIVATE "MARL_DEBUG_ENABLED=1")
+    endif()
+
+    if(CMAKE_SYSTEM_PROCESSOR MATCHES "rv*")
+        target_link_libraries(${target} INTERFACE atomic) #explicitly use -latomic for RISC-V linking
     endif()
 
     target_include_directories(${target} PUBLIC $<BUILD_INTERFACE:${MARL_INCLUDE_DIR}>)

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Marl is a C++ 11 library that provides a fluent interface for running tasks acro
 
 Marl uses a combination of fibers and threads to allow efficient execution of tasks that can block, while keeping a fixed number of hardware threads.
 
-Marl supports Windows, macOS, Linux, FreeBSD, Fuchsia, Android and iOS (arm, aarch64, mips64, ppc64, x86 and x64).
+Marl supports Windows, macOS, Linux, FreeBSD, Fuchsia, Android and iOS (arm, aarch64, mips64, ppc64, rv64, x86 and x64).
 
 Marl has no dependencies on other libraries (with an exception on googletest for building the optional unit tests).
 

--- a/src/osfiber_asm.h
+++ b/src/osfiber_asm.h
@@ -34,6 +34,8 @@
 #include "osfiber_asm_ppc64.h"
 #elif defined(__mips__) && _MIPS_SIM == _ABI64
 #include "osfiber_asm_mips64.h"
+#elif defined(__riscv) && __riscv_xlen == 64
+#include "osfiber_asm_rv64.h"
 #else
 #error "Unsupported target"
 #endif

--- a/src/osfiber_asm_rv64.S
+++ b/src/osfiber_asm_rv64.S
@@ -1,0 +1,100 @@
+// Copyright 2021 The Marl Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#if defined(__riscv) && __riscv_xlen == 64
+
+#define MARL_BUILD_ASM 1
+#include "osfiber_asm_rv64.h"
+
+// void marl_fiber_swap(marl_fiber_context* from, const marl_fiber_context* to)
+// a0: from
+// a1: to
+.text
+.global marl_fiber_swap
+.align 4
+marl_fiber_swap:
+
+    // Save context 'from'
+
+    // Store callee-preserved registers
+    sd  s0, MARL_REG_s0(a0)
+    sd  s1, MARL_REG_s1(a0)
+    sd  s2, MARL_REG_s2(a0)
+    sd  s3, MARL_REG_s3(a0)
+    sd  s4, MARL_REG_s4(a0)
+    sd  s5, MARL_REG_s5(a0)
+    sd  s6, MARL_REG_s6(a0)
+    sd  s7, MARL_REG_s7(a0)
+    sd  s8, MARL_REG_s8(a0)
+    sd  s9, MARL_REG_s9(a0)
+    sd  s10, MARL_REG_s10(a0)
+    sd  s11, MARL_REG_s11(a0)
+
+    fsd  fs0, MARL_REG_fs0(a0)
+    fsd  fs1, MARL_REG_fs1(a0)
+    fsd  fs2, MARL_REG_fs2(a0)
+    fsd  fs3, MARL_REG_fs3(a0)
+    fsd  fs4, MARL_REG_fs4(a0)
+    fsd  fs5, MARL_REG_fs5(a0)
+    fsd  fs6, MARL_REG_fs6(a0)
+    fsd  fs7, MARL_REG_fs7(a0)
+    fsd  fs8, MARL_REG_fs8(a0)
+    fsd  fs9, MARL_REG_fs9(a0)
+    fsd  fs10, MARL_REG_fs10(a0)
+    fsd  fs11, MARL_REG_fs11(a0)
+
+    sd  sp, MARL_REG_sp(a0)
+    // On RISC-V ra is caller-saved
+    // but we need ra to jump to the trampoline
+    sd  ra, MARL_REG_ra(a0)
+
+    move  t0, a1 // Store a1 in temporary register
+
+    // Recover callee-preserved registers
+    ld  s0, MARL_REG_s0(t0)
+    ld  s1, MARL_REG_s1(t0)
+    ld  s2, MARL_REG_s2(t0)
+    ld  s3, MARL_REG_s3(t0)
+    ld  s4, MARL_REG_s4(t0)
+    ld  s5, MARL_REG_s5(t0)
+    ld  s6, MARL_REG_s6(t0)
+    ld  s7, MARL_REG_s7(t0)
+    ld  s8, MARL_REG_s8(t0)
+    ld  s9, MARL_REG_s9(t0)
+    ld  s10, MARL_REG_s10(t0)
+    ld  s11, MARL_REG_s11(t0)
+
+    fld  fs0, MARL_REG_fs0(t0)
+    fld  fs1, MARL_REG_fs1(t0)
+    fld  fs2, MARL_REG_fs2(t0)
+    fld  fs3, MARL_REG_fs3(t0)
+    fld  fs4, MARL_REG_fs4(t0)
+    fld  fs5, MARL_REG_fs5(t0)
+    fld  fs6, MARL_REG_fs6(t0)
+    fld  fs7, MARL_REG_fs7(t0)
+    fld  fs8, MARL_REG_fs8(t0)
+    fld  fs9, MARL_REG_fs9(t0)
+    fld  fs10, MARL_REG_fs10(t0)
+    fld  fs11, MARL_REG_fs11(t0)
+
+    ld  sp, MARL_REG_sp(t0)
+    ld  ra, MARL_REG_ra(t0)
+
+    // Recover arguments
+    ld  a0, MARL_REG_a0(t0)
+    ld  a1, MARL_REG_a1(t0)
+
+    jr	ra // Jump to the trampoline
+
+#endif // defined(__riscv) && __riscv_xlen == 64

--- a/src/osfiber_asm_rv64.h
+++ b/src/osfiber_asm_rv64.h
@@ -1,0 +1,145 @@
+// Copyright 2021 The Marl Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+#define MARL_REG_a0 0x00
+#define MARL_REG_a1 0x08
+#define MARL_REG_s0 0x10
+#define MARL_REG_s1 0x18
+#define MARL_REG_s2 0x20
+#define MARL_REG_s3 0x28
+#define MARL_REG_s4 0x30
+#define MARL_REG_s5 0x38
+#define MARL_REG_s6 0x40
+#define MARL_REG_s7 0x48
+#define MARL_REG_s8 0x50
+#define MARL_REG_s9 0x58
+#define MARL_REG_s10 0x60
+#define MARL_REG_s11 0x68
+#define MARL_REG_fs0 0x70
+#define MARL_REG_fs1 0x78
+#define MARL_REG_fs2 0x80
+#define MARL_REG_fs3 0x88
+#define MARL_REG_fs4 0x90
+#define MARL_REG_fs5 0x98
+#define MARL_REG_fs6 0xa0
+#define MARL_REG_fs7 0xa8
+#define MARL_REG_fs8 0xb0
+#define MARL_REG_fs9 0xb8
+#define MARL_REG_fs10 0xc0
+#define MARL_REG_fs11 0xc8
+#define MARL_REG_sp 0xd0
+#define MARL_REG_ra 0xd8
+
+#ifndef MARL_BUILD_ASM
+
+#include <stdint.h>
+
+struct marl_fiber_context {
+  // parameter registers (First two)
+  uintptr_t a0;
+  uintptr_t a1;
+
+  // callee-saved registers
+  uintptr_t s0;
+  uintptr_t s1;
+  uintptr_t s2;
+  uintptr_t s3;
+  uintptr_t s4;
+  uintptr_t s5;
+  uintptr_t s6;
+  uintptr_t s7;
+  uintptr_t s8;
+  uintptr_t s9;
+  uintptr_t s10;
+  uintptr_t s11;
+
+  uintptr_t fs0;
+  uintptr_t fs1;
+  uintptr_t fs2;
+  uintptr_t fs3;
+  uintptr_t fs4;
+  uintptr_t fs5;
+  uintptr_t fs6;
+  uintptr_t fs7;
+  uintptr_t fs8;
+  uintptr_t fs9;
+  uintptr_t fs10;
+  uintptr_t fs11;
+
+  uintptr_t sp;
+  uintptr_t ra;
+};
+
+#ifdef __cplusplus
+#include <cstddef>
+static_assert(offsetof(marl_fiber_context, a0) == MARL_REG_a0,
+              "Bad register offset");
+static_assert(offsetof(marl_fiber_context, a1) == MARL_REG_a1,
+              "Bad register offset");
+static_assert(offsetof(marl_fiber_context, s0) == MARL_REG_s0,
+              "Bad register offset");
+static_assert(offsetof(marl_fiber_context, s1) == MARL_REG_s1,
+              "Bad register offset");
+static_assert(offsetof(marl_fiber_context, s2) == MARL_REG_s2,
+              "Bad register offset");
+static_assert(offsetof(marl_fiber_context, s3) == MARL_REG_s3,
+              "Bad register offset");
+static_assert(offsetof(marl_fiber_context, s4) == MARL_REG_s4,
+              "Bad register offset");
+static_assert(offsetof(marl_fiber_context, s5) == MARL_REG_s5,
+              "Bad register offset");
+static_assert(offsetof(marl_fiber_context, s6) == MARL_REG_s6,
+              "Bad register offset");
+static_assert(offsetof(marl_fiber_context, s7) == MARL_REG_s7,
+              "Bad register offset");
+static_assert(offsetof(marl_fiber_context, s8) == MARL_REG_s8,
+              "Bad register offset");
+static_assert(offsetof(marl_fiber_context, s9) == MARL_REG_s9,
+              "Bad register offset");
+static_assert(offsetof(marl_fiber_context, s10) == MARL_REG_s10,
+              "Bad register offset");
+static_assert(offsetof(marl_fiber_context, s11) == MARL_REG_s11,
+              "Bad register offset");
+static_assert(offsetof(marl_fiber_context, fs0) == MARL_REG_fs0,
+              "Bad register offset");
+static_assert(offsetof(marl_fiber_context, fs1) == MARL_REG_fs1,
+              "Bad register offset");
+static_assert(offsetof(marl_fiber_context, fs2) == MARL_REG_fs2,
+              "Bad register offset");
+static_assert(offsetof(marl_fiber_context, fs3) == MARL_REG_fs3,
+              "Bad register offset");
+static_assert(offsetof(marl_fiber_context, fs4) == MARL_REG_fs4,
+              "Bad register offset");
+static_assert(offsetof(marl_fiber_context, fs5) == MARL_REG_fs5,
+              "Bad register offset");
+static_assert(offsetof(marl_fiber_context, fs6) == MARL_REG_fs6,
+              "Bad register offset");
+static_assert(offsetof(marl_fiber_context, fs7) == MARL_REG_fs7,
+              "Bad register offset");
+static_assert(offsetof(marl_fiber_context, fs8) == MARL_REG_fs8,
+              "Bad register offset");
+static_assert(offsetof(marl_fiber_context, fs9) == MARL_REG_fs9,
+              "Bad register offset");
+static_assert(offsetof(marl_fiber_context, fs10) == MARL_REG_fs10,
+              "Bad register offset");
+static_assert(offsetof(marl_fiber_context, fs11) == MARL_REG_fs11,
+              "Bad register offset");
+static_assert(offsetof(marl_fiber_context, sp) == MARL_REG_sp,
+              "Bad register offset");
+static_assert(offsetof(marl_fiber_context, ra) == MARL_REG_ra,
+              "Bad register offset");
+#endif  // __cplusplus
+
+#endif  // MARL_BUILD_ASM

--- a/src/osfiber_rv64.c
+++ b/src/osfiber_rv64.c
@@ -1,0 +1,39 @@
+// Copyright 2021 The Marl Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#if defined(__riscv) && __riscv_xlen == 64
+
+#include "osfiber_asm_rv64.h"
+
+#include "marl/export.h"
+
+MARL_EXPORT
+void marl_fiber_trampoline(void (*target)(void*), void* arg) {
+  target(arg);
+}
+
+MARL_EXPORT
+void marl_fiber_set_target(struct marl_fiber_context* ctx,
+                           void* stack,
+                           uint32_t stack_size,
+                           void (*target)(void*),
+                           void* arg) {
+  uintptr_t* stack_top = (uintptr_t*)((uint8_t*)(stack) + stack_size);
+  ctx->ra = (uintptr_t)&marl_fiber_trampoline;
+  ctx->a0 = (uintptr_t)target;
+  ctx->a1 = (uintptr_t)arg;
+  ctx->sp = ((uintptr_t)stack_top) & ~(uintptr_t)15;
+}
+
+#endif  // defined(__riscv) && __riscv_xlen == 64


### PR DESCRIPTION
Based on guide in #207.

Tests successfully pass:
```
[----------] Global test environment tear-down
[==========] 316 tests from 5 test suites ran. (64964 ms total)
[  PASSED  ] 316 tests.
```

However the `AllocatorTest.Guards` test currently produces an unhandled signal:
```
[----------] 3 tests from AllocatorTest
[ RUN      ] AllocatorTest.AlignedAllocate
[       OK ] AllocatorTest.AlignedAllocate (39 ms)
[ RUN      ] AllocatorTest.Create
[       OK ] AllocatorTest.Create (0 ms)
[ RUN      ] AllocatorTest.Guards
[115975.450455] marl-unittests[37537]: unhandled signal 11 code 0x2 at 0x0000003fa12eefff in marl-unittests[2aae64b000+2ea000]
[115975.450927] CPU: 0 PID: 37537 Comm: marl-unittests Tainted: G            E     5.15.0-2-riscv64 #1  Debian 5.15.5-1
[115975.451204] Hardware name: riscv-virtio,qemu (DT)
[115975.451337] epc : 0000002aae7f67e4 ra : 0000002aae7f67d8 sp : 0000003fd7c37530
[115975.451504]  gp : 0000002aae93eb10 tp : 0000003fa0f497b0 t0 : 0000003fa1248f36
[115975.451666]  t1 : 0000002aae7a3f3c t2 : 0000000000000000 s0 : 0000003fd7c37670
[115975.451835]  s1 : 0000000000000000 a0 : 0000000000000001 a1 : 0000002ac3aa24b0
[115975.451994]  a2 : 0000000000000000 a3 : 0000000000000000 a4 : 0000000000000001
[115975.452168]  a5 : 0000003fa12eefff a6 : 0000003fa0f49118 a7 : 0000000000000039
[115975.452367]  s2 : 0000002b1a125f60 s3 : 0000000000000000 s4 : 0000002b1a126850
[115975.452552]  s5 : 0000003f9f5242c8 s6 : 0000002b1a11f260 s7 : 0000002b1a1264d0
[115975.453570]  s8 : 0000002b1a126770 s9 : 0000002b1a126850 s10: 0000002ae4ad5858
[115975.454008]  s11: 0000002ae4ad57c8 t3 : 0000003fa1197356 t4 : 00183e66ac000000
[115975.454226]  t5 : ffffffffffffffff t6 : 0000010e0b5f240b
[115975.454605] status: 0000000000004020 badaddr: 0000003fa12eefff cause: 000000000000000f
[115975.499495] marl-unittests[37538]: unhandled signal 11 code 0x2 at 0x0000003fa12f0000 in marl-unittests[2aae64b000+2ea000]
[115975.500182] CPU: 0 PID: 37538 Comm: marl-unittests Tainted: G            E     5.15.0-2-riscv64 #1  Debian 5.15.5-1
[115975.500488] Hardware name: riscv-virtio,qemu (DT)
[115975.501073] epc : 0000002aae7f6970 ra : 0000002aae7f6966 sp : 0000003fd7c37530
[115975.501291]  gp : 0000002aae93eb10 tp : 0000003fa0f497b0 t0 : 0000000000000001
[115975.501522]  t1 : 0000002aae7a3f3c t2 : 00000000000003ff s0 : 0000003fd7c37670
[115975.501768]  s1 : 0000000000000000 a0 : 0000000000001000 a1 : 0000002ac3abcd60
[115975.501997]  a2 : 0000000000000000 a3 : 0000000000000000 a4 : 0000000000000001
[115975.502238]  a5 : 0000003fa12f0000 a6 : 0000003fa0f49118 a7 : 0000000000000039
[115975.502475]  s2 : 0000002aae8354dc s3 : 0000000000000000 s4 : 0000002b1a126850
[115975.502718]  s5 : 0000003f9f5242c8 s6 : 0000002b1a11f260 s7 : 0000002b1a1264d0
[115975.502996]  s8 : 0000002b1a126770 s9 : 0000002b1a126850 s10: 0000002ae4ad5858
[115975.503256]  s11: 0000002ae4ad57c8 t3 : 0000003fa1197356 t4 : 001aa0c0ac000000
[115975.503465]  t5 : ffffffffffffffff t6 : 0000010e0b653e8b
[115975.503638] status: 0000000000004020 badaddr: 0000003fa12f0000 cause: 000000000000000f
[       OK ] AllocatorTest.Guards (75 ms)
[----------] 3 tests from AllocatorTest (117 ms total)
```