### PR TITLE
kokoro: Fix ASAN build

### DIFF
--- a/kokoro/ubuntu/presubmit.sh
+++ b/kokoro/ubuntu/presubmit.sh
@@ -19,7 +19,9 @@ set -e # Fail on any error.
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd )"
 ROOT_DIR="$( cd "${SCRIPT_DIR}/../.." >/dev/null 2>&1 && pwd )"
 
+# --privileged is required for some sanitizer builds, as they seem to require PTRACE privileges
 docker run --rm -i \
+  --privileged \
   --volume "${ROOT_DIR}:${ROOT_DIR}" \
   --workdir "${ROOT_DIR}" \
   --env BUILD_SYSTEM=${BUILD_SYSTEM} \

--- a/kokoro/ubuntu/release.sh
+++ b/kokoro/ubuntu/release.sh
@@ -19,7 +19,9 @@ set -e # Fail on any error.
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd )"
 ROOT_DIR="$( cd "${SCRIPT_DIR}/../.." >/dev/null 2>&1 && pwd )"
 
+# --privileged is required for some sanitizer builds, as they seem to require PTRACE privileges
 docker run --rm -i \
+  --privileged \
   --volume "${ROOT_DIR}:${ROOT_DIR}" \
   --volume "${KOKORO_ARTIFACTS_DIR}:/mnt/artifacts" \
   --workdir "${ROOT_DIR}" \


### PR DESCRIPTION
The VM has been updated to Kokoro 14.04, and now the docker instance requires escalated privileges in order to run some sanitizer builds.