### PR TITLE
Allow Affinity to be constructed from a vector

### DIFF
--- a/include/marl/thread.h
+++ b/include/marl/thread.h
@@ -99,6 +99,9 @@ class Thread {
 
     MARL_EXPORT Affinity(std::initializer_list<Core>, Allocator* allocator);
 
+    MARL_EXPORT Affinity(const containers::vector<Core, 32>&,
+                         Allocator* allocator);
+
     // count() returns the number of enabled cores in the affinity.
     MARL_EXPORT size_t count() const;
 

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -129,6 +129,10 @@ Thread::Affinity::Affinity(std::initializer_list<Core> list,
   }
 }
 
+Thread::Affinity::Affinity(const containers::vector<Core, 32>& coreList,
+                           Allocator* allocator)
+    : cores(coreList, allocator) {}
+
 Thread::Affinity Thread::Affinity::all(
     Allocator* allocator /* = Allocator::Default */) {
   Thread::Affinity affinity(allocator);

--- a/src/thread_test.cpp
+++ b/src/thread_test.cpp
@@ -100,6 +100,20 @@ TEST_F(WithoutBoundScheduler, ThreadAffinityAllCountNonzero) {
   }
 }
 
+TEST_F(WithoutBoundScheduler, ThreadAffinityFromVector) {
+  marl::containers::vector<marl::Thread::Core, 32> cores(allocator);
+  cores.push_back(core(10));
+  cores.push_back(core(20));
+  cores.push_back(core(30));
+  cores.push_back(core(40));
+  auto affinity = marl::Thread::Affinity(cores, allocator);
+  EXPECT_EQ(affinity.count(), cores.size());
+  EXPECT_EQ(affinity[0], core(10));
+  EXPECT_EQ(affinity[1], core(20));
+  EXPECT_EQ(affinity[2], core(30));
+  EXPECT_EQ(affinity[3], core(40));
+}
+
 TEST_F(WithoutBoundScheduler, ThreadAffinityPolicyOneOf) {
   auto all = marl::Thread::Affinity(
       {


### PR DESCRIPTION
Currently Affinity only has a `std::initializer_list` based constructor. This change adds a constructor that accepts a `containers::vector`, to make it easier to build an Affinity object dynamically (think vector derived from an affinity mask).