### PR TITLE
Add loongarch64 support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -161,11 +161,13 @@ if(NOT MSVC)
         ${MARL_SRC_DIR}/osfiber_asm_mips64.S
         ${MARL_SRC_DIR}/osfiber_asm_ppc64.S
         ${MARL_SRC_DIR}/osfiber_asm_rv64.S
+	${MARL_SRC_DIR}/osfiber_asm_loongarch64.S
         ${MARL_SRC_DIR}/osfiber_asm_x64.S
         ${MARL_SRC_DIR}/osfiber_asm_x86.S
         ${MARL_SRC_DIR}/osfiber_mips64.c
         ${MARL_SRC_DIR}/osfiber_ppc64.c
         ${MARL_SRC_DIR}/osfiber_rv64.c
+	${MARL_SRC_DIR}/osfiber_loongarch64.c
         ${MARL_SRC_DIR}/osfiber_x64.c
         ${MARL_SRC_DIR}/osfiber_x86.c
     )
@@ -179,6 +181,7 @@ if(NOT MSVC)
         ${MARL_SRC_DIR}/osfiber_asm_ppc64.S
         ${MARL_SRC_DIR}/osfiber_asm_x64.S
         ${MARL_SRC_DIR}/osfiber_asm_x86.S
+	${MARL_SRC_DIR}/osfiber_asm_loongarch64.S
         PROPERTIES LANGUAGE C
     )
 endif(NOT MSVC)

--- a/src/osfiber_asm.h
+++ b/src/osfiber_asm.h
@@ -36,6 +36,8 @@
 #include "osfiber_asm_mips64.h"
 #elif defined(__riscv) && __riscv_xlen == 64
 #include "osfiber_asm_rv64.h"
+#elif defined(__loongarch__) && _LOONGARCH_SIM == _ABILP64
+#include "osfiber_asm_loongarch64.h"
 #else
 #error "Unsupported target"
 #endif

--- a/src/osfiber_asm_loongarch64.S
+++ b/src/osfiber_asm_loongarch64.S
@@ -1,0 +1,86 @@
+// Copyright 2022 The Marl Authors.
+//
+// Licensed under the Apache License. Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at 
+//
+// 	https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#if defined(__loongarch__) && _LOONGARCH_SIM == _ABILP64
+
+#define MARL_BUILD_ASM 1
+#include "osfiber_asm_loongarch64.h"
+
+// void marl_fiber_swap(marl_fiber_context* from, const marl_fiber_context* to)
+// a0: from
+// a1: to
+.text
+.global marl_fiber_swap
+.align 4
+marl_fiber_swap:
+
+	// Save context 'from'
+
+	// Store callee-preserved registers
+	st.d $s0, $a0, MARL_REG_s0
+	st.d $s1, $a0, MARL_REG_s1
+	st.d $s2, $a0, MARL_REG_s2
+	st.d $s3, $a0, MARL_REG_s3
+	st.d $s4, $a0, MARL_REG_s4
+	st.d $s5, $a0, MARL_REG_s5
+	st.d $s6, $a0, MARL_REG_s6
+	st.d $s7, $a0, MARL_REG_s7
+	st.d $s8, $a0, MARL_REG_s8
+
+	fst.d $fs0, $a0, MARL_REG_fs0
+	fst.d $fs1, $a0, MARL_REG_fs1
+	fst.d $fs2, $a0, MARL_REG_fs2
+	fst.d $fs3, $a0, MARL_REG_fs3
+	fst.d $fs4, $a0, MARL_REG_fs4
+	fst.d $fs5, $a0, MARL_REG_fs5
+	fst.d $fs6, $a0, MARL_REG_fs6
+	fst.d $fs7, $a0, MARL_REG_fs7
+
+	st.d $ra, $a0, MARL_REG_ra
+	st.d $sp, $a0, MARL_REG_sp
+	st.d $fp, $a0, MARL_REG_fp
+
+	move $t0, $a1 // Store a1 in temporary register
+
+	// Recover callee-preserved registers
+	ld.d $s0, $t0, MARL_REG_s0
+	ld.d $s1, $t0, MARL_REG_s1
+	ld.d $s2, $t0, MARL_REG_s2
+	ld.d $s3, $t0, MARL_REG_s3
+	ld.d $s4, $t0, MARL_REG_s4
+	ld.d $s5, $t0, MARL_REG_s5
+	ld.d $s6, $t0, MARL_REG_s6
+	ld.d $s7, $t0, MARL_REG_s7
+	ld.d $s8, $t0, MARL_REG_s8
+
+	fld.d $fs0, $t0, MARL_REG_fs0
+	fld.d $fs1, $t0, MARL_REG_fs1
+	fld.d $fs2, $t0, MARL_REG_fs2
+	fld.d $fs3, $t0, MARL_REG_fs3
+	fld.d $fs4, $t0, MARL_REG_fs4
+	fld.d $fs5, $t0, MARL_REG_fs5
+	fld.d $fs6, $t0, MARL_REG_fs6
+	fld.d $fs7, $t0, MARL_REG_fs7
+
+	ld.d $ra, $t0, MARL_REG_ra
+	ld.d $sp, $t0, MARL_REG_sp
+	ld.d $fp, $t0, MARL_REG_fp
+
+	// Recover arguments
+	ld.d $a0, $t0, MARL_REG_a0
+	ld.d $a1, $t0, MARL_REG_a1
+
+	jr	$ra // Jump to the trampoline
+
+#endif // defined(__loongarch__) && _LOONGARCH_SIM == _ABILP64

--- a/src/osfiber_asm_loongarch64.h
+++ b/src/osfiber_asm_loongarch64.h
@@ -1,0 +1,120 @@
+// Copyright 2022 The Marl Authors.
+//
+// Licensed under the Apache License. Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at 
+//
+// 	https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#define MARL_REG_a0 0x00
+#define MARL_REG_a1 0x08
+#define MARL_REG_s0 0x10
+#define MARL_REG_s1 0x18
+#define MARL_REG_s2 0x20
+#define MARL_REG_s3 0x28
+#define MARL_REG_s4 0x30
+#define MARL_REG_s5 0x38
+#define MARL_REG_s6 0x40
+#define MARL_REG_s7 0x48
+#define MARL_REG_s8 0x50
+#define MARL_REG_fs0 0x58
+#define MARL_REG_fs1 0x60
+#define MARL_REG_fs2 0x68
+#define MARL_REG_fs3 0x70
+#define MARL_REG_fs4 0x78
+#define MARL_REG_fs5 0x80
+#define MARL_REG_fs6 0x88
+#define MARL_REG_fs7 0x90
+#define MARL_REG_ra 0x98
+#define MARL_REG_sp 0xa0
+#define MARL_REG_fp 0xa8
+
+#ifndef MARL_BUILD_ASM
+
+#include <stdint.h>
+
+struct marl_fiber_context {
+  // paramater registers (First two)
+  uintptr_t a0;
+  uintptr_t a1;
+
+  // callee-saved registers
+  uintptr_t s0;
+  uintptr_t s1;
+  uintptr_t s2;
+  uintptr_t s3;
+  uintptr_t s4;
+  uintptr_t s5;
+  uintptr_t s6;
+  uintptr_t s7;
+  uintptr_t s8;
+
+  uintptr_t fs0;
+  uintptr_t fs1;
+  uintptr_t fs2;
+  uintptr_t fs3;
+  uintptr_t fs4;
+  uintptr_t fs5;
+  uintptr_t fs6;
+  uintptr_t fs7;
+
+  uintptr_t ra;
+  uintptr_t sp;
+  uintptr_t fp;
+};
+
+#ifdef __cplusplus
+#include <cstddef>
+static_assert(offsetof(marl_fiber_context, a0) == MARL_REG_a0, 
+	      "Bad register offset");
+static_assert(offsetof(marl_fiber_context, a1) == MARL_REG_a1, 
+	      "Bad register offset");
+static_assert(offsetof(marl_fiber_context, s0) == MARL_REG_s0, 
+	      "Bad register offset");
+static_assert(offsetof(marl_fiber_context, s1) == MARL_REG_s1, 
+	      "Bad register offset");
+static_assert(offsetof(marl_fiber_context, s2) == MARL_REG_s2, 
+	      "Bad register offset");
+static_assert(offsetof(marl_fiber_context, s3) == MARL_REG_s3, 
+	      "Bad register offset");
+static_assert(offsetof(marl_fiber_context, s4) == MARL_REG_s4, 
+	      "Bad register offset");
+static_assert(offsetof(marl_fiber_context, s5) == MARL_REG_s5, 
+	      "Bad register offset");
+static_assert(offsetof(marl_fiber_context, s6) == MARL_REG_s6, 
+	      "Bad register offset");
+static_assert(offsetof(marl_fiber_context, s7) == MARL_REG_s7, 
+	      "Bad register offset");
+static_assert(offsetof(marl_fiber_context, s8) == MARL_REG_s8, 
+	      "Bad register offset");
+static_assert(offsetof(marl_fiber_context, fs0) == MARL_REG_fs0, 
+	      "Bad register offset");
+static_assert(offsetof(marl_fiber_context, fs1) == MARL_REG_fs1, 
+	      "Bad register offset");
+static_assert(offsetof(marl_fiber_context, fs2) == MARL_REG_fs2, 
+	      "Bad register offset");
+static_assert(offsetof(marl_fiber_context, fs3) == MARL_REG_fs3, 
+	      "Bad register offset");
+static_assert(offsetof(marl_fiber_context, fs4) == MARL_REG_fs4, 
+	      "Bad register offset");
+static_assert(offsetof(marl_fiber_context, fs5) == MARL_REG_fs5, 
+	      "Bad register offset");
+static_assert(offsetof(marl_fiber_context, fs6) == MARL_REG_fs6, 
+	      "Bad register offset");
+static_assert(offsetof(marl_fiber_context, fs7) == MARL_REG_fs7, 
+	      "Bad register offset");
+static_assert(offsetof(marl_fiber_context, ra) == MARL_REG_ra, 
+	      "Bad register offset");
+static_assert(offsetof(marl_fiber_context, sp) == MARL_REG_sp, 
+	      "Bad register offset");
+static_assert(offsetof(marl_fiber_context, fp) == MARL_REG_fp, 
+	      "Bad register offset");
+#endif // __cplusplus
+
+#endif // MARL_BUILD_ASM

--- a/src/osfiber_loongarch64.c
+++ b/src/osfiber_loongarch64.c
@@ -1,0 +1,39 @@
+// Copyright 2022 The Marl Authors.
+//
+// Licensed under the Apache License. Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at 
+//
+// 	https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#if defined(__loongarch__)  && _LOONGARCH_SIM == _ABILP64
+
+#include "osfiber_asm_loongarch64.h"
+
+#include "marl/export.h"
+
+MARL_EXPORT
+void marl_fiber_trampoline(void (*target)(void*), void* arg) {
+  target(arg);
+}
+
+MARL_EXPORT
+void marl_fiber_set_target(struct marl_fiber_context* ctx,
+			   void* stack,
+			   uint32_t stack_size,
+			   void (*target)(void*),
+			   void* arg) {
+  uintptr_t* stack_top = (uintptr_t*)((uint8_t*)(stack) + stack_size);
+  ctx->ra = (uintptr_t)&marl_fiber_trampoline;
+  ctx->a0 = (uintptr_t)target;
+  ctx->a1 = (uintptr_t)arg;
+  ctx->sp = ((uintptr_t)stack_top) & ~(uintptr_t)15;
+}
+
+#endif // defined(__loongarch__) && _LOONGARCH_SIM == _ABILP64


### PR DESCRIPTION
Porting marl to loongarch64 a new 64-bit architecture.

The new architecture ABI document link:
[https://github.com/loongson/LoongArch-Documentation](url)

My machine architecture:
`root@loongson-pc:~/marl/build# arch
loongarch64
`
Tests successfully pass:
`[ RUN      ] SchedulerParams/WithBoundScheduler.Ticket/2
[       OK ] SchedulerParams/WithBoundScheduler.Ticket/2 (35 ms)
[ RUN      ] SchedulerParams/WithBoundScheduler.Ticket/3
[       OK ] SchedulerParams/WithBoundScheduler.Ticket/3 (5 ms)
[ RUN      ] SchedulerParams/WithBoundScheduler.Ticket/4
[       OK ] SchedulerParams/WithBoundScheduler.Ticket/4 (7 ms)
[ RUN      ] SchedulerParams/WithBoundScheduler.Ticket/5
[       OK ] SchedulerParams/WithBoundScheduler.Ticket/5 (11 ms)
[ RUN      ] SchedulerParams/WithBoundScheduler.WaitGroup_OneTask/0
[       OK ] SchedulerParams/WithBoundScheduler.WaitGroup_OneTask/0 (0 ms)
[ RUN      ] SchedulerParams/WithBoundScheduler.WaitGroup_OneTask/1
[       OK ] SchedulerParams/WithBoundScheduler.WaitGroup_OneTask/1 (0 ms)
[ RUN      ] SchedulerParams/WithBoundScheduler.WaitGroup_OneTask/2
[       OK ] SchedulerParams/WithBoundScheduler.WaitGroup_OneTask/2 (0 ms)
[ RUN      ] SchedulerParams/WithBoundScheduler.WaitGroup_OneTask/3
[       OK ] SchedulerParams/WithBoundScheduler.WaitGroup_OneTask/3 (2 ms)
[ RUN      ] SchedulerParams/WithBoundScheduler.WaitGroup_OneTask/4
[       OK ] SchedulerParams/WithBoundScheduler.WaitGroup_OneTask/4 (1 ms)
[ RUN      ] SchedulerParams/WithBoundScheduler.WaitGroup_OneTask/5
[       OK ] SchedulerParams/WithBoundScheduler.WaitGroup_OneTask/5 (4 ms)
[ RUN      ] SchedulerParams/WithBoundScheduler.WaitGroup_10Tasks/0
[       OK ] SchedulerParams/WithBoundScheduler.WaitGroup_10Tasks/0 (0 ms)
[ RUN      ] SchedulerParams/WithBoundScheduler.WaitGroup_10Tasks/1
[       OK ] SchedulerParams/WithBoundScheduler.WaitGroup_10Tasks/1 (0 ms)
[ RUN      ] SchedulerParams/WithBoundScheduler.WaitGroup_10Tasks/2
[       OK ] SchedulerParams/WithBoundScheduler.WaitGroup_10Tasks/2 (1 ms)
[ RUN      ] SchedulerParams/WithBoundScheduler.WaitGroup_10Tasks/3
[       OK ] SchedulerParams/WithBoundScheduler.WaitGroup_10Tasks/3 (1 ms)
[ RUN      ] SchedulerParams/WithBoundScheduler.WaitGroup_10Tasks/4
[       OK ] SchedulerParams/WithBoundScheduler.WaitGroup_10Tasks/4 (1 ms)
[ RUN      ] SchedulerParams/WithBoundScheduler.WaitGroup_10Tasks/5
[       OK ] SchedulerParams/WithBoundScheduler.WaitGroup_10Tasks/5 (5 ms)
[----------] 276 tests from SchedulerParams/WithBoundScheduler (8173 ms total)

[----------] Global test environment tear-down
[==========] 317 tests from 5 test suites ran. (8212 ms total)
[  PASSED  ] 317 tests.
`