### PR TITLE
scheduler: Support moved tast captures / arguments

### DIFF
--- a/src/scheduler_test.cpp
+++ b/src/scheduler_test.cpp
@@ -20,6 +20,7 @@
 #include "marl/waitgroup.h"
 
 #include <atomic>
+#include <memory>
 
 TEST_F(WithoutBoundScheduler, SchedulerConstructAndDestruct) {
   auto scheduler = std::unique_ptr<marl::Scheduler>(
@@ -106,6 +107,36 @@ TEST_P(WithBoundScheduler, ScheduleWithArgs) {
       "a string", 42, true);
   wg.wait();
   ASSERT_EQ(got, "s: 'a string', i: 42, b: true");
+}
+
+TEST_P(WithBoundScheduler, ScheduleWithMovedCapture) {
+#if __cplusplus >= 201402L  // C++14 or greater
+  std::unique_ptr<std::string> move_me(new std::string("move me"));
+  std::string got;
+  marl::WaitGroup wg(1);
+  marl::schedule([moved = std::move(move_me), wg, &got]() {
+    got = *moved;
+    wg.done();
+  });
+  wg.wait();
+  ASSERT_EQ(got, "move me");
+#else
+  GTEST_SKIP() << "Test requires c++14 or greater";
+#endif
+}
+
+TEST_P(WithBoundScheduler, ScheduleWithMovedArg) {
+  std::unique_ptr<std::string> move_me(new std::string("move me"));
+  std::string got;
+  marl::WaitGroup wg(1);
+  marl::schedule(
+      [wg, &got](std::unique_ptr<std::string>& str) {
+        got = *str;
+        wg.done();
+      },
+      std::move(move_me));
+  wg.wait();
+  ASSERT_EQ(got, "move me");
 }
 
 TEST_P(WithBoundScheduler, FibersResumeOnSameThread) {


### PR DESCRIPTION
Replace the internal use of `std::function` with `std::packaged_task`.
`std::function` requires that the wrapped function is CopyConstructable, where as a `std::packaged_task` does not.
This allows the tasks to hold `std::move`'d values.

This is an API / ABI breaking change, but I believe few people would be copying `marl::Task`s.

Fixes: #211