### PR TITLE
[loongarch64] Remove the code that copied a1 to t0 register

### DIFF
--- a/src/osfiber_asm_loongarch64.S
+++ b/src/osfiber_asm_loongarch64.S
@@ -51,35 +51,33 @@ marl_fiber_swap:
 	st.d $sp, $a0, MARL_REG_sp
 	st.d $fp, $a0, MARL_REG_fp
 
-	move $t0, $a1 // Store a1 in temporary register
-
 	// Recover callee-preserved registers
-	ld.d $s0, $t0, MARL_REG_s0
-	ld.d $s1, $t0, MARL_REG_s1
-	ld.d $s2, $t0, MARL_REG_s2
-	ld.d $s3, $t0, MARL_REG_s3
-	ld.d $s4, $t0, MARL_REG_s4
-	ld.d $s5, $t0, MARL_REG_s5
-	ld.d $s6, $t0, MARL_REG_s6
-	ld.d $s7, $t0, MARL_REG_s7
-	ld.d $s8, $t0, MARL_REG_s8
+	ld.d $s0, $a1, MARL_REG_s0
+	ld.d $s1, $a1, MARL_REG_s1
+	ld.d $s2, $a1, MARL_REG_s2
+	ld.d $s3, $a1, MARL_REG_s3
+	ld.d $s4, $a1, MARL_REG_s4
+	ld.d $s5, $a1, MARL_REG_s5
+	ld.d $s6, $a1, MARL_REG_s6
+	ld.d $s7, $a1, MARL_REG_s7
+	ld.d $s8, $a1, MARL_REG_s8
 
-	fld.d $fs0, $t0, MARL_REG_fs0
-	fld.d $fs1, $t0, MARL_REG_fs1
-	fld.d $fs2, $t0, MARL_REG_fs2
-	fld.d $fs3, $t0, MARL_REG_fs3
-	fld.d $fs4, $t0, MARL_REG_fs4
-	fld.d $fs5, $t0, MARL_REG_fs5
-	fld.d $fs6, $t0, MARL_REG_fs6
-	fld.d $fs7, $t0, MARL_REG_fs7
+	fld.d $fs0, $a1, MARL_REG_fs0
+	fld.d $fs1, $a1, MARL_REG_fs1
+	fld.d $fs2, $a1, MARL_REG_fs2
+	fld.d $fs3, $a1, MARL_REG_fs3
+	fld.d $fs4, $a1, MARL_REG_fs4
+	fld.d $fs5, $a1, MARL_REG_fs5
+	fld.d $fs6, $a1, MARL_REG_fs6
+	fld.d $fs7, $a1, MARL_REG_fs7
 
-	ld.d $ra, $t0, MARL_REG_ra
-	ld.d $sp, $t0, MARL_REG_sp
-	ld.d $fp, $t0, MARL_REG_fp
+	ld.d $ra, $a1, MARL_REG_ra
+	ld.d $sp, $a1, MARL_REG_sp
+	ld.d $fp, $a1, MARL_REG_fp
 
 	// Recover arguments
-	ld.d $a0, $t0, MARL_REG_a0
-	ld.d $a1, $t0, MARL_REG_a1
+	ld.d $a0, $a1, MARL_REG_a0
+	ld.d $a1, $a1, MARL_REG_a1
 
 	jr	$ra // Jump to the trampoline
 

--- a/src/osfiber_asm_loongarch64.h
+++ b/src/osfiber_asm_loongarch64.h
@@ -39,6 +39,8 @@
 
 #include <stdint.h>
 
+// Procedure Call Standard for the LoongArch 64-bit Architecture
+// https://loongson.github.io/LoongArch-Documentation/LoongArch-ELF-ABI-EN.html
 struct marl_fiber_context {
   // paramater registers (First two)
   uintptr_t a0;


### PR DESCRIPTION
base to #215 

The test successfully passed after modifying the code:

```
[       OK ] SchedulerParams/WithBoundScheduler.WaitGroup_OneTask/5 (4 ms)
[ RUN      ] SchedulerParams/WithBoundScheduler.WaitGroup_10Tasks/0
[       OK ] SchedulerParams/WithBoundScheduler.WaitGroup_10Tasks/0 (0 ms)
[ RUN      ] SchedulerParams/WithBoundScheduler.WaitGroup_10Tasks/1
[       OK ] SchedulerParams/WithBoundScheduler.WaitGroup_10Tasks/1 (0 ms)
[ RUN      ] SchedulerParams/WithBoundScheduler.WaitGroup_10Tasks/2
[       OK ] SchedulerParams/WithBoundScheduler.WaitGroup_10Tasks/2 (1 ms)
[ RUN      ] SchedulerParams/WithBoundScheduler.WaitGroup_10Tasks/3
[       OK ] SchedulerParams/WithBoundScheduler.WaitGroup_10Tasks/3 (1 ms)
[ RUN      ] SchedulerParams/WithBoundScheduler.WaitGroup_10Tasks/4
[       OK ] SchedulerParams/WithBoundScheduler.WaitGroup_10Tasks/4 (1 ms)
[ RUN      ] SchedulerParams/WithBoundScheduler.WaitGroup_10Tasks/5
[       OK ] SchedulerParams/WithBoundScheduler.WaitGroup_10Tasks/5 (5 ms)
[----------] 276 tests from SchedulerParams/WithBoundScheduler (8285 ms total)

[----------] Global test environment tear-down
[==========] 317 tests from 5 test suites ran. (8332 ms total)
[  PASSED  ] 317 tests.

```