### PR TITLE
Reland "Unpoison thread_local variables for MSAN (#228)"

### DIFF
--- a/include/marl/sanitizers.h
+++ b/include/marl/sanitizers.h
@@ -78,13 +78,14 @@
 #define THREAD_SANITIZER_ONLY(x)
 #endif  // THREAD_SANITIZER_ENABLED
 
-// The CLANG_NO_SANITIZE_MEMORY macro suppresses MemorySanitizer checks for
-// use-of-uninitialized-data. It can be used to decorate functions with known
-// false positives.
-#ifdef __clang__
-#define CLANG_NO_SANITIZE_MEMORY __attribute__((no_sanitize_memory))
+// The MSAN_UNPOISON macro marks uninitialized memory as initialized for MSAN.
+// It can be used to suppress false-positive MSAN errors before reading
+// thread-local variables. See https://github.com/google/sanitizers/issues/1265
+#if MEMORY_SANITIZER_ENABLED
+#include <sanitizer/msan_interface.h>
+#define MSAN_UNPOISON(p, size) __msan_unpoison(p, size)
 #else
-#define CLANG_NO_SANITIZE_MEMORY
+#define MSAN_UNPOISON(p, size)
 #endif
 
 #endif  // marl_sanitizers_h

--- a/include/marl/scheduler.h
+++ b/include/marl/scheduler.h
@@ -21,6 +21,7 @@
 #include "export.h"
 #include "memory.h"
 #include "mutex.h"
+#include "sanitizers.h"
 #include "task.h"
 #include "thread.h"
 
@@ -573,6 +574,7 @@ bool Scheduler::Fiber::wait(
 }
 
 Scheduler::Worker* Scheduler::Worker::getCurrent() {
+  MSAN_UNPOISON(&current, sizeof(Worker*));
   return Worker::current;
 }
 


### PR DESCRIPTION
This is a reland of e2d3d0bf24884e948e7e3e14888d921d4ad7e808. The issue with the original change was unpoisoning the pointee when really the pointer needs to be unpoisoned. Verified that a sample Chromium web test [1] fails with the original change and passes with the new change.

[1] external/wpt/accessibility/crashtests/aria-owns-fallback-content.html

Delta from original change:

diff --git a/include/marl/scheduler.h b/include/marl/scheduler.h index 54b5732..48acf02 100644
--- a/include/marl/scheduler.h
+++ b/include/marl/scheduler.h
@@ -574,7 +574,7 @@ bool Scheduler::Fiber::wait(
 }

 Scheduler::Worker* Scheduler::Worker::getCurrent() {
-  MSAN_UNPOISON(current, sizeof(Worker));
+  MSAN_UNPOISON(&current, sizeof(Worker*)); return Worker::current; }

diff --git a/src/scheduler.cpp b/src/scheduler.cpp index e91ac5d..43c2c1c 100644
--- a/src/scheduler.cpp
+++ b/src/scheduler.cpp
@@ -87,7 +87,7 @@ namespace marl {
 thread_local Scheduler* Scheduler::bound = nullptr;

 Scheduler* Scheduler::get() {
-  MSAN_UNPOISON(bound, sizeof(Scheduler));
+  MSAN_UNPOISON(&bound, sizeof(Scheduler*)); return bound; }

Original change description:

> The current method of working around MSAN errors for thread-local
> variables by annotating getters and setters with
> CLANG_NO_SANITIZE_MEMORY was insufficient because the getters
> don't actually dereference the memory.  Rather, all functions
> that dereference the pointers must be annotated with
> CLANG_NO_SANITIZE_MEMORY, which is error-prone.  This PR switches
> to an alternative workaround that unpoisons the memory in the
> getter.
>
> This false-positive MSAN issue is seen when trying to upgrade
> Chromium MSAN bots from Ubuntu 18.04 to 20.04, and should be fixed
> by this PR.