### PR TITLE
Add MSVC check to the __nop call

### DIFF
--- a/src/scheduler.cpp
+++ b/src/scheduler.cpp
@@ -60,7 +60,7 @@ inline uint64_t threadID() {
 #endif
 
 inline void nop() {
-#if defined(_WIN32)
+#if defined(_MSC_VER)
   __nop();
 #else
   __asm__ __volatile__("nop");


### PR DESCRIPTION
Marl fails to build on MinGW-w64 on Windows because __nop is a MSC instruction.