### PR TITLE
Fix build issue with GetModuleHandle when using UNICODE

### DIFF
--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -332,7 +332,7 @@ void Thread::join() {
 void Thread::setName(const char* fmt, ...) {
   static auto setThreadDescription =
       reinterpret_cast<HRESULT(WINAPI*)(HANDLE, PCWSTR)>(GetProcAddress(
-          GetModuleHandle("kernelbase.dll"), "SetThreadDescription"));
+          GetModuleHandleA("kernelbase.dll"), "SetThreadDescription"));
   if (setThreadDescription == nullptr) {
     return;
   }


### PR DESCRIPTION
Per the *UTF-8 Everywhere Manifesto*, it's best to not rely on the legacy ANSI .vs UNICODE macros for Win32 functions that take strings. Since you explicitly use an ANSI string for the call to ``GetModuleHandle`` you should explicitly use the ``GetModuleHandleA`` method.

> This causes problems when trying to build your library using vcpkg manager when the setup adds the recommended UNICODE _UNICODE defines.
