### PR TITLE
Emscripten support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,10 @@ project(Marl
     LANGUAGES C CXX ASM
 )
 
+if (EMSCRIPTEN)
+    add_compile_options(-O3 -pthread)
+endif()
+
 include(CheckCXXSourceCompiles)
 
 # MARL_IS_SUBPROJECT is 1 if added via add_subdirectory() from another project.
@@ -392,6 +396,16 @@ if(MARL_BUILD_EXAMPLES)
         set_target_properties(${target} PROPERTIES FOLDER "Examples")
         marl_set_target_options(${target})
         target_link_libraries(${target} PRIVATE marl)
+        if (EMSCRIPTEN)
+            target_link_options(${target} PRIVATE
+                    -O1
+                    -pthread -sPTHREAD_POOL_SIZE=2 -sPROXY_TO_PTHREAD
+                    -sASYNCIFY # -sASYNCIFY_STACK_SIZE=1000000
+                    -sALLOW_MEMORY_GROWTH=1 -sASSERTIONS
+                    -sENVIRONMENT=web,worker
+                    "SHELL:--shell-file ${CMAKE_CURRENT_SOURCE_DIR}/examples/shell.emscripten.html")
+            set_target_properties(${target} PROPERTIES SUFFIX .html)
+        endif()
     endfunction(build_example)
 
     build_example(fractal)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -170,6 +170,7 @@ if(NOT MSVC)
         ${MARL_SRC_DIR}/osfiber_rv64.c
         ${MARL_SRC_DIR}/osfiber_x64.c
         ${MARL_SRC_DIR}/osfiber_x86.c
+        ${MARL_SRC_DIR}/osfiber_emscripten.cpp
     )
     # CMAKE_OSX_ARCHITECTURES settings aren't propagated to assembly files when
     # building for Apple platforms (https://gitlab.kitware.com/cmake/cmake/-/issues/20771),

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Marl is a C++ 11 library that provides a fluent interface for running tasks acro
 
 Marl uses a combination of fibers and threads to allow efficient execution of tasks that can block, while keeping a fixed number of hardware threads.
 
-Marl supports Windows, macOS, Linux, FreeBSD, Fuchsia, Android and iOS (arm, aarch64, loongarch64, mips64, ppc64, rv64, x86 and x64).
+Marl supports Windows, macOS, Linux, FreeBSD, Fuchsia, Emscripten, Android and iOS (arm, aarch64, loongarch64, mips64, ppc64, rv64, x86 and x64).
 
 Marl has no dependencies on other libraries (with an exception on googletest for building the optional unit tests).
 
@@ -92,6 +92,26 @@ make
 ```
 
 The resulting binaries will be found in `<path-to-marl>/build`
+
+### Emscripten
+
+1. install and activate the emscripten sdk following [standard instructions for your platform](https://emscripten.org/docs/getting_started/downloads.html).
+2. build an example from the examples folder using emscripten, say `hello_task`. 
+```bash
+cd <path-to-marl>
+mkdir build
+cd build
+emcmake cmake .. -DMARL_BUILD_EXAMPLES=1
+make hello_task -j 8
+```
+NOTE: you want to change the value of the linker flag `sPTHREAD_POOL_SIZE` that must be at least as large as the number of threads used by your application.
+3. Test the emscripten output.
+You can use the provided python script to create a local web server:
+```bash
+../run_webserver
+```
+In your browser, navigate to the example URL: [http://127.0.0.1:8080/hello_task.html](http://127.0.0.1:8080/hello_task.html).  
+Voilà - you should see the log output appear on the web page.
 
 ### Installing Marl (vcpkg)
 

--- a/examples/run_webserver
+++ b/examples/run_webserver
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+"""
+Runs a COOE/COEP local webserver for testing emscripten deployment.
+Note:
+    Browsers that have implemented and enabled SharedArrayBuffer are gating it behind Cross Origin Opener Policy (COOP)
+    and Cross Origin Embedder Policy (COEP) headers.
+    Pthreads code will not work in deployed environment unless these headers are correctly set.
+    see: https://emscripten.org/docs/porting/pthreads.html
+"""
+
+from http.server import HTTPServer, SimpleHTTPRequestHandler
+
+
+class RequestHandler(SimpleHTTPRequestHandler):
+    def end_headers(self):
+        self.send_header("Access-Control-Allow-Origin", "*")
+        self.send_header("Cross-Origin-Embedder-Policy", "require-corp")
+        self.send_header("Cross-Origin-Opener-Policy", "same-origin")
+        super().end_headers()
+
+
+def main():
+
+    addr = "127.0.0.1"
+    port = 8080
+    httpd = HTTPServer((addr, port), RequestHandler)
+    print("Serving http at http://{}:{}".format(addr, port))
+
+    try:
+        httpd.serve_forever()
+    except KeyboardInterrupt:
+        print("\nBye.")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/run_webserver
+++ b/examples/run_webserver
@@ -1,5 +1,19 @@
 #!/usr/bin/env python3
 """
+// Copyright 2023 The Marl Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 Runs a COOE/COEP local webserver for testing emscripten deployment.
 Note:
     Browsers that have implemented and enabled SharedArrayBuffer are gating it behind Cross Origin Opener Policy (COOP)

--- a/examples/run_webserver
+++ b/examples/run_webserver
@@ -1,19 +1,5 @@
 #!/usr/bin/env python3
 """
-// Copyright 2023 The Marl Authors.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
 Runs a COOE/COEP local webserver for testing emscripten deployment.
 Note:
     Browsers that have implemented and enabled SharedArrayBuffer are gating it behind Cross Origin Opener Policy (COOP)

--- a/examples/shell.emscripten.html
+++ b/examples/shell.emscripten.html
@@ -14,8 +14,6 @@
       .emscripten { padding-right: 0; margin-left: auto; margin-right: auto; display: block; }
       div.emscripten { text-align: center; }
       div.emscripten_border { border: 1px solid black; }
-      /* the canvas *must not* have any border or padding, or mouse coords will be wrong */
-      canvas.emscripten { border: 0px none; background-color: black; }
 
       #emscripten_logo {
         display: inline-block;
@@ -111,9 +109,6 @@
 </div>
 
 
-<div class="emscripten_border">
-    <canvas class="emscripten" id="canvas" oncontextmenu="event.preventDefault()" tabindex=-1></canvas>
-</div>
 <textarea id="output" rows="8"></textarea>
 
 <script type='text/javascript'>
@@ -140,16 +135,6 @@
               element.scrollTop = element.scrollHeight; // focus on bottom
             }
           };
-        })(),
-        canvas: (function() {
-          var canvas = document.getElementById('canvas');
-
-          // As a default initial behavior, pop up an alert when webgl context is lost. To make your
-          // application robust, you may want to override this behavior before shipping!
-          // See http://www.khronos.org/registry/webgl/specs/latest/1.0/#5.15.2
-          canvas.addEventListener("webglcontextlost", function(e) { alert('WebGL context lost. You will need to reload the page.'); e.preventDefault(); }, false);
-
-          return canvas;
         })(),
         setStatus: function(text) {
           if (!Module.setStatus.last) Module.setStatus.last = { time: Date.now(), text: '' };

--- a/examples/shell.emscripten.html
+++ b/examples/shell.emscripten.html
@@ -1,0 +1,194 @@
+<!doctype html>
+<html lang="en-us">
+<head>
+    <meta charset="utf-8">
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+    <title>Emscripten-Generated Code</title>
+    <style>
+      body {
+        font-family: arial;
+        margin: 0;
+        padding: none;
+      }
+
+      .emscripten { padding-right: 0; margin-left: auto; margin-right: auto; display: block; }
+      div.emscripten { text-align: center; }
+      div.emscripten_border { border: 1px solid black; }
+      /* the canvas *must not* have any border or padding, or mouse coords will be wrong */
+      canvas.emscripten { border: 0px none; background-color: black; }
+
+      #emscripten_logo {
+        display: inline-block;
+        margin: 0;
+      }
+
+      .spinner {
+        height: 30px;
+        width: 30px;
+        margin: 0;
+        margin-top: 20px;
+        margin-left: 20px;
+        display: inline-block;
+        vertical-align: top;
+
+        -webkit-animation: rotation .8s linear infinite;
+        -moz-animation: rotation .8s linear infinite;
+        -o-animation: rotation .8s linear infinite;
+        animation: rotation 0.8s linear infinite;
+
+        border-left: 5px solid rgb(235, 235, 235);
+        border-right: 5px solid rgb(235, 235, 235);
+        border-bottom: 5px solid rgb(235, 235, 235);
+        border-top: 5px solid rgb(120, 120, 120);
+
+        border-radius: 100%;
+        background-color: rgb(189, 215, 46);
+      }
+
+      @-webkit-keyframes rotation {
+        from {-webkit-transform: rotate(0deg);}
+        to {-webkit-transform: rotate(360deg);}
+      }
+      @-moz-keyframes rotation {
+        from {-moz-transform: rotate(0deg);}
+        to {-moz-transform: rotate(360deg);}
+      }
+      @-o-keyframes rotation {
+        from {-o-transform: rotate(0deg);}
+        to {-o-transform: rotate(360deg);}
+      }
+      @keyframes rotation {
+        from {transform: rotate(0deg);}
+        to {transform: rotate(360deg);}
+      }
+
+      #status {
+        display: inline-block;
+        vertical-align: top;
+        margin-top: 30px;
+        margin-left: 20px;
+        font-weight: bold;
+        color: rgb(120, 120, 120);
+      }
+
+      #progress {
+        height: 20px;
+        width: 300px;
+      }
+
+      #controls {
+        display: inline-block;
+        float: right;
+        vertical-align: top;
+        margin-top: 30px;
+        margin-right: 20px;
+      }
+
+      #output {
+        width: 100%;
+        height: 200px;
+        margin: 0 auto;
+        margin-top: 10px;
+        border-left: 0px;
+        border-right: 0px;
+        padding-left: 0px;
+        padding-right: 0px;
+        display: block;
+        background-color: black;
+        color: white;
+        font-family: 'Lucida Console', Monaco, monospace;
+        outline: none;
+      }
+    </style>
+</head>
+<body>
+
+<div class="spinner" id='spinner'></div>
+<div class="emscripten" id="status">Downloading...</div>
+
+<div class="emscripten">
+    <progress value="0" max="100" id="progress" hidden=1></progress>
+</div>
+
+
+<div class="emscripten_border">
+    <canvas class="emscripten" id="canvas" oncontextmenu="event.preventDefault()" tabindex=-1></canvas>
+</div>
+<textarea id="output" rows="8"></textarea>
+
+<script type='text/javascript'>
+      var statusElement = document.getElementById('status');
+      var progressElement = document.getElementById('progress');
+      var spinnerElement = document.getElementById('spinner');
+
+      var Module = {
+        preRun: [],
+        postRun: [],
+        print: (function() {
+          var element = document.getElementById('output');
+          if (element) element.value = ''; // clear browser cache
+          return function(text) {
+            if (arguments.length > 1) text = Array.prototype.slice.call(arguments).join(' ');
+            // These replacements are necessary if you render to raw HTML
+            //text = text.replace(/&/g, "&amp;");
+            //text = text.replace(/</g, "&lt;");
+            //text = text.replace(/>/g, "&gt;");
+            //text = text.replace('\n', '<br>', 'g');
+            console.log(text);
+            if (element) {
+              element.value += text + "\n";
+              element.scrollTop = element.scrollHeight; // focus on bottom
+            }
+          };
+        })(),
+        canvas: (function() {
+          var canvas = document.getElementById('canvas');
+
+          // As a default initial behavior, pop up an alert when webgl context is lost. To make your
+          // application robust, you may want to override this behavior before shipping!
+          // See http://www.khronos.org/registry/webgl/specs/latest/1.0/#5.15.2
+          canvas.addEventListener("webglcontextlost", function(e) { alert('WebGL context lost. You will need to reload the page.'); e.preventDefault(); }, false);
+
+          return canvas;
+        })(),
+        setStatus: function(text) {
+          if (!Module.setStatus.last) Module.setStatus.last = { time: Date.now(), text: '' };
+          if (text === Module.setStatus.last.text) return;
+          var m = text.match(/([^(]+)\((\d+(\.\d+)?)\/(\d+)\)/);
+          var now = Date.now();
+          if (m && now - Module.setStatus.last.time < 30) return; // if this is a progress update, skip it if too soon
+          Module.setStatus.last.time = now;
+          Module.setStatus.last.text = text;
+          if (m) {
+            text = m[1];
+            progressElement.value = parseInt(m[2])*100;
+            progressElement.max = parseInt(m[4])*100;
+            progressElement.hidden = false;
+            spinnerElement.hidden = false;
+          } else {
+            progressElement.value = null;
+            progressElement.max = null;
+            progressElement.hidden = true;
+            if (!text) spinnerElement.style.display = 'none';
+          }
+          statusElement.innerHTML = text;
+        },
+        totalDependencies: 0,
+        monitorRunDependencies: function(left) {
+          this.totalDependencies = Math.max(this.totalDependencies, left);
+          Module.setStatus(left ? 'Preparing... (' + (this.totalDependencies-left) + '/' + this.totalDependencies + ')' : 'All downloads complete.');
+        }
+      };
+      Module.setStatus('Downloading...');
+      window.onerror = function(event) {
+        // TODO: do not warn on ok events like simulating an infinite loop or exitStatus
+        Module.setStatus('Exception thrown, see JavaScript console');
+        spinnerElement.style.display = 'none';
+        Module.setStatus = function(text) {
+          if (text) console.error('[post-exception status] ' + text);
+        };
+      };
+    </script>
+{{{ SCRIPT }}}
+</body>
+</html>

--- a/examples/shell.emscripten.html
+++ b/examples/shell.emscripten.html
@@ -1,3 +1,17 @@
+// Copyright 2023 The Marl Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 <!doctype html>
 <html lang="en-us">
 <head>

--- a/examples/shell.emscripten.html
+++ b/examples/shell.emscripten.html
@@ -1,17 +1,3 @@
-// Copyright 2023 The Marl Authors.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
 <!doctype html>
 <html lang="en-us">
 <head>

--- a/include/marl/containers.h
+++ b/include/marl/containers.h
@@ -145,15 +145,15 @@ class vector {
 
 template <typename T, int BASE_CAPACITY>
 vector<T, BASE_CAPACITY>::vector(
-    Allocator* allocator /* = Allocator::Default */)
-    : allocator(allocator) {}
+    Allocator* allocator_ /* = Allocator::Default */)
+    : allocator(allocator_) {}
 
 template <typename T, int BASE_CAPACITY>
 template <int BASE_CAPACITY_2>
 vector<T, BASE_CAPACITY>::vector(
     const vector<T, BASE_CAPACITY_2>& other,
-    Allocator* allocator /* = Allocator::Default */)
-    : allocator(allocator) {
+    Allocator* allocator_ /* = Allocator::Default */)
+    : allocator(allocator_) {
   *this = other;
 }
 
@@ -161,8 +161,8 @@ template <typename T, int BASE_CAPACITY>
 template <int BASE_CAPACITY_2>
 vector<T, BASE_CAPACITY>::vector(
     vector<T, BASE_CAPACITY_2>&& other,
-    Allocator* allocator /* = Allocator::Default */)
-    : allocator(allocator) {
+    Allocator* allocator_ /* = Allocator::Default */)
+    : allocator(allocator_) {
   *this = std::move(other);
 }
 
@@ -417,7 +417,7 @@ class list {
 };
 
 template <typename T>
-list<T>::iterator::iterator(Entry* entry) : entry(entry) {}
+list<T>::iterator::iterator(Entry* entry_) : entry(entry_) {}
 
 template <typename T>
 T* list<T>::iterator::operator->() {
@@ -446,8 +446,8 @@ bool list<T>::iterator::operator!=(const iterator& rhs) const {
 }
 
 template <typename T>
-list<T>::list(Allocator* allocator /* = Allocator::Default */)
-    : allocator(allocator) {}
+list<T>::list(Allocator* allocator_ /* = Allocator::Default */)
+    : allocator(allocator_) {}
 
 template <typename T>
 list<T>::~list() {

--- a/include/marl/event.h
+++ b/include/marl/event.h
@@ -128,8 +128,8 @@ class Event {
   const std::shared_ptr<Shared> shared;
 };
 
-Event::Shared::Shared(Allocator* allocator, Mode mode, bool initialState)
-    : cv(allocator), mode(mode), signalled(initialState) {}
+Event::Shared::Shared(Allocator* allocator, Mode mode_, bool initialState)
+    : cv(allocator), mode(mode_), signalled(initialState) {}
 
 void Event::Shared::signal() {
   marl::lock lock(mutex);

--- a/include/marl/finally.h
+++ b/include/marl/finally.h
@@ -58,10 +58,10 @@ class FinallyImpl : public Finally {
 };
 
 template <typename F>
-FinallyImpl<F>::FinallyImpl(const F& func) : func(func) {}
+FinallyImpl<F>::FinallyImpl(const F& func_) : func(func_) {}
 
 template <typename F>
-FinallyImpl<F>::FinallyImpl(F&& func) : func(std::move(func)) {}
+FinallyImpl<F>::FinallyImpl(F&& func_) : func(std::move(func_)) {}
 
 template <typename F>
 FinallyImpl<F>::FinallyImpl(FinallyImpl<F>&& other)

--- a/include/marl/memory.h
+++ b/include/marl/memory.h
@@ -154,8 +154,8 @@ class Allocator {
 // Allocator::Deleter
 ///////////////////////////////////////////////////////////////////////////////
 Allocator::Deleter::Deleter() : allocator(nullptr) {}
-Allocator::Deleter::Deleter(Allocator* allocator, size_t count)
-    : allocator(allocator), count(count) {}
+Allocator::Deleter::Deleter(Allocator* allocator_, size_t count_)
+    : allocator(allocator_), count(count_) {}
 
 template <typename T>
 void Allocator::Deleter::operator()(T* object) {
@@ -289,8 +289,8 @@ size_t TrackedAllocator::Stats::bytesAllocated() const {
   return out;
 }
 
-TrackedAllocator::TrackedAllocator(Allocator* allocator)
-    : allocator(allocator) {}
+TrackedAllocator::TrackedAllocator(Allocator* allocator_)
+    : allocator(allocator_) {}
 
 TrackedAllocator::Stats TrackedAllocator::stats() {
   std::unique_lock<std::mutex> lock(mutex);
@@ -388,7 +388,7 @@ struct StlAllocator {
 };
 
 template <typename T>
-StlAllocator<T>::StlAllocator(Allocator* allocator) : allocator(allocator) {}
+StlAllocator<T>::StlAllocator(Allocator* allocator_) : allocator(allocator_) {}
 
 template <typename T>
 template <typename U>

--- a/include/marl/task.h
+++ b/include/marl/task.h
@@ -64,10 +64,10 @@ class Task {
 Task::Task() {}
 Task::Task(const Task& o) : function(o.function), flags(o.flags) {}
 Task::Task(Task&& o) : function(std::move(o.function)), flags(o.flags) {}
-Task::Task(const Function& function, Flags flags /* = Flags::None */)
-    : function(function), flags(flags) {}
-Task::Task(Function&& function, Flags flags /* = Flags::None */)
-    : function(std::move(function)), flags(flags) {}
+Task::Task(const Function& function_, Flags flags_ /* = Flags::None */)
+    : function(function_), flags(flags_) {}
+Task::Task(Function&& function_, Flags flags_ /* = Flags::None */)
+    : function(std::move(function_)), flags(flags_) {}
 Task& Task::operator=(const Task& o) {
   function = o.function;
   flags = o.flags;

--- a/license-checker.cfg
+++ b/license-checker.cfg
@@ -18,7 +18,9 @@
                 "docs/imgs/*.svg",
                 "kokoro/**.cfg",
                 "third_party/benchmark/**",
-                "third_party/googletest/**"
+                "third_party/googletest/**",
+                "examples/run_webserver",
+                "examples/shell.emscripten.html"
             ]
         }
     ]

--- a/src/memory.cpp
+++ b/src/memory.cpp
@@ -19,7 +19,7 @@
 
 #include <cstring>
 
-#if defined(__linux__) || defined(__FreeBSD__) || defined(__APPLE__)
+#if defined(__linux__) || defined(__FreeBSD__) || defined(__APPLE__) || defined(__EMSCRIPTEN__)
 #include <sys/mman.h>
 #include <unistd.h>
 namespace {

--- a/src/osfiber_asm.h
+++ b/src/osfiber_asm.h
@@ -52,6 +52,13 @@
 
 extern "C" {
 
+#if defined(__EMSCRIPTEN__)
+MARL_EXPORT
+void marl_main_fiber_init(marl_fiber_context* ctx);
+#else
+MARL_EXPORT
+inline void marl_main_fiber_init(marl_fiber_context*) {}
+#endif
 MARL_EXPORT
 extern void marl_fiber_set_target(marl_fiber_context*,
                                   void* stack,
@@ -110,6 +117,7 @@ Allocator::unique_ptr<OSFiber> OSFiber::createFiberFromCurrentThread(
     Allocator* allocator) {
   auto out = allocator->make_unique<OSFiber>(allocator);
   out->context = {};
+  marl_main_fiber_init(&out->context);
   return out;
 }
 

--- a/src/osfiber_asm.h
+++ b/src/osfiber_asm.h
@@ -38,6 +38,8 @@
 #include "osfiber_asm_rv64.h"
 #elif defined(__loongarch__) && _LOONGARCH_SIM == _ABILP64
 #include "osfiber_asm_loongarch64.h"
+#elif defined(__EMSCRIPTEN__)
+#include "osfiber_emscripten.h"
 #else
 #error "Unsupported target"
 #endif

--- a/src/osfiber_emscripten.cpp
+++ b/src/osfiber_emscripten.cpp
@@ -1,0 +1,65 @@
+// Copyright 2019 The Marl Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#if defined(__EMSCRIPTEN__)
+
+#include "osfiber_emscripten.h"
+
+#include "marl/export.h"
+
+
+extern "C" {
+
+static marl_fiber_context main_fiber;
+static marl_fiber_context* running_fiber = nullptr;
+
+MARL_EXPORT
+void marl_fiber_trampoline(void (*target)(void*), void* arg) {
+  target(arg);
+}
+
+MARL_EXPORT
+void marl_fiber_set_target(marl_fiber_context* ctx,
+                           void* stack,
+                           uint32_t stack_size,
+                           void (*target)(void*),
+                           void* arg) {
+
+  if(running_fiber == nullptr) {
+    emscripten_fiber_init_from_current_context(
+          &main_fiber.context,
+          main_fiber.asyncify_stack.data(),
+          main_fiber.asyncify_stack.size());
+
+    running_fiber = &main_fiber;
+  }
+
+  emscripten_fiber_init(
+          &ctx->context,
+          target,
+          arg,
+          stack,
+          stack_size,
+          ctx->asyncify_stack.data(),
+          ctx->asyncify_stack.size());
+}
+
+MARL_EXPORT
+extern void marl_fiber_swap(marl_fiber_context* from,
+                            const marl_fiber_context* to) {
+
+  emscripten_fiber_swap(&from->context, const_cast<emscripten_fiber_t*>(&to->context));
+}
+}
+#endif  // defined(__EMSCRIPTEN__)

--- a/src/osfiber_emscripten.cpp
+++ b/src/osfiber_emscripten.cpp
@@ -21,12 +21,17 @@
 
 extern "C" {
 
-static marl_fiber_context main_fiber;
-static marl_fiber_context* running_fiber = nullptr;
-
 MARL_EXPORT
 void marl_fiber_trampoline(void (*target)(void*), void* arg) {
   target(arg);
+}
+
+MARL_EXPORT
+void marl_main_fiber_init(marl_fiber_context* ctx) {
+  emscripten_fiber_init_from_current_context(
+          &ctx->context,
+          ctx->asyncify_stack.data(),
+          ctx->asyncify_stack.size());
 }
 
 MARL_EXPORT
@@ -35,15 +40,6 @@ void marl_fiber_set_target(marl_fiber_context* ctx,
                            uint32_t stack_size,
                            void (*target)(void*),
                            void* arg) {
-
-  if(running_fiber == nullptr) {
-    emscripten_fiber_init_from_current_context(
-          &main_fiber.context,
-          main_fiber.asyncify_stack.data(),
-          main_fiber.asyncify_stack.size());
-
-    running_fiber = &main_fiber;
-  }
 
   emscripten_fiber_init(
           &ctx->context,
@@ -58,7 +54,6 @@ void marl_fiber_set_target(marl_fiber_context* ctx,
 MARL_EXPORT
 extern void marl_fiber_swap(marl_fiber_context* from,
                             const marl_fiber_context* to) {
-
   emscripten_fiber_swap(&from->context, const_cast<emscripten_fiber_t*>(&to->context));
 }
 }

--- a/src/osfiber_emscripten.cpp
+++ b/src/osfiber_emscripten.cpp
@@ -1,4 +1,4 @@
-// Copyright 2019 The Marl Authors.
+// Copyright 2023 The Marl Authors.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/osfiber_emscripten.h
+++ b/src/osfiber_emscripten.h
@@ -1,0 +1,30 @@
+// Copyright 2019 The Marl Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef MARL_BUILD_WASM
+
+#include <cstdint>
+#include <cstddef>
+#include <array>
+#include <emscripten.h>
+#include <emscripten/fiber.h>
+
+struct marl_fiber_context {
+  // callee-saved data
+  static constexpr size_t asyncify_stack_size = 1024 * 1024;
+  emscripten_fiber_t context;
+  std::array</*std::byte*/ char, asyncify_stack_size> asyncify_stack;
+};
+
+#endif  // MARL_BUILD_ASM

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -426,7 +426,7 @@ void Thread::setName(const char* fmt, ...) {
   pthread_setname_np(name);
 #elif defined(__FreeBSD__)
   pthread_set_name_np(pthread_self(), name);
-#elif !defined(__Fuchsia__)
+#elif !defined(__Fuchsia__) && !defined(__EMSCRIPTEN__)
   pthread_setname_np(pthread_self(), name);
 #endif
 


### PR DESCRIPTION
I am a total emscripten beginner (picked it up last week for the purpose of marl integration) but I managed to get the marl examples to run in the browser, which is nice. 
I updated the readme with what should be simple steps. Let me know if I have missed anything.

One change worth noting : I had to extend the marl low-level API by adding `marl_main_fiber_init` for the purpose of initializing the first (main) fiber on a given emscripten thread. It reflects the `emscripten_fiber_init_from_current_context` emscripten/fiber primitive. From the emscripten doc: 

> This is needed in order to switch back from a fiber into the thread’s original context.

For all other platforms, that method does nothing.

---- 
I would recommend squashing the commits (not sure if I can do that on my end).