### PR TITLE
Explicitly #include <utility> in finally.h

### DIFF
--- a/include/marl/finally.h
+++ b/include/marl/finally.h
@@ -28,6 +28,7 @@
 
 #include <functional>
 #include <memory>
+#include <utility>
 
 namespace marl {
 


### PR DESCRIPTION
finally.h uses std::move(...), which is declared in the <utility> header. This currently compiles because std::move is provided by transitive libc++ modules, but this transitive include is not guaranteed to exist, as was found when compiling chrome with Clang modules (https://crbug.com/543704).