### PR TITLE
Fix Android host build

### DIFF
--- a/include/marl/thread.h
+++ b/include/marl/thread.h
@@ -52,7 +52,8 @@ class Thread {
   struct Affinity {
     // supported is true if marl supports controlling thread affinity for this
     // platform.
-#if defined(_WIN32) || (defined(__linux__) && !defined(__ANDROID__)) || \
+#if defined(_WIN32) ||                                                       \
+    (defined(__linux__) && !defined(__ANDROID__) && !defined(__BIONIC__)) || \
     defined(__FreeBSD__)
     static constexpr bool supported = true;
 #else

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -150,7 +150,7 @@ Thread::Affinity Thread::Affinity::all(
       }
     }
   }
-#elif defined(__linux__) && !defined(__ANDROID__)
+#elif defined(__linux__) && !defined(__ANDROID__) && !defined(__BIONIC__)
   auto thread = pthread_self();
   cpu_set_t cpuset;
   CPU_ZERO(&cpuset);
@@ -379,7 +379,7 @@ class Thread::Impl {
       return;
     }
 
-#if defined(__linux__) && !defined(__ANDROID__)
+#if defined(__linux__) && !defined(__ANDROID__) && !defined(__BIONIC__)
     cpu_set_t cpuset;
     CPU_ZERO(&cpuset);
     for (size_t i = 0; i < count; i++) {


### PR DESCRIPTION
Errors seen on earlier patchsets of aosp/2528699:

  error: use of undeclared identifier 'pthread_getaffinity_np'

  error: use of undeclared identifier 'pthread_setaffinity_np';
  did you mean 'sched_setaffinity'?

Potentially same as https://github.com/google/marl/pull/154 but for the host builds which do not have __ANDROID__ defined?