### PR TITLE
Fixed a race condition causing some workers to perform multiple tasks serially while other workers sleep.

### DIFF
--- a/include/marl/scheduler.h
+++ b/include/marl/scheduler.h
@@ -417,10 +417,11 @@ class Scheduler {
     // spinForWork().
     void waitForWork() REQUIRES(work.mutex);
 
-    // spinForWork() attempts to steal work from another Worker, and keeps
+    // spinForWorkAndLock() attempts to steal work from another Worker, and keeps
     // the thread awake for a short duration. This reduces overheads of
-    // frequently putting the thread to sleep and re-waking.
-    void spinForWork();
+    // frequently putting the thread to sleep and re-waking. It locks the mutex
+    // before returning so that a stolen task cannot be re-stolen by other workers.
+    void spinForWorkAndLock() ACQUIRE(work.mutex);
 
     // enqueueFiberTimeouts() enqueues all the fibers that have finished
     // waiting.
@@ -498,7 +499,7 @@ class Scheduler {
   // The immutable configuration used to build the scheduler.
   const Config cfg;
 
-  std::array<std::atomic<int>, 8> spinningWorkers;
+  std::array<std::atomic<int>, MaxWorkerThreads> spinningWorkers;
   std::atomic<unsigned int> nextSpinningWorkerIdx = {0x8000000};
 
   std::atomic<unsigned int> nextEnqueueIndex = {0};

--- a/src/scheduler.cpp
+++ b/src/scheduler.cpp
@@ -130,10 +130,8 @@ Scheduler::Scheduler(const Config& config)
     : cfg(setConfigDefaults(config)),
       workerThreads{},
       singleThreadedWorkers(config.allocator) {
-  for (size_t i = 0; i < spinningWorkers.size(); i++) {
-    spinningWorkers[i] = -1;
-  }
   for (int i = 0; i < cfg.workerThread.count; i++) {
+    spinningWorkers[i] = -1;
     workerThreads[i] =
         cfg.allocator->create<Worker>(this, Worker::Mode::MultiThreaded, i);
   }
@@ -170,7 +168,7 @@ void Scheduler::enqueue(Task&& task) {
   if (cfg.workerThread.count > 0) {
     while (true) {
       // Prioritize workers that have recently started spinning.
-      auto i = --nextSpinningWorkerIdx % spinningWorkers.size();
+      auto i = --nextSpinningWorkerIdx % cfg.workerThread.count;
       auto idx = spinningWorkers[i].exchange(-1);
       if (idx < 0) {
         // If a spinning worker couldn't be found, round-robin the
@@ -212,7 +210,7 @@ bool Scheduler::stealWork(Worker* thief, uint64_t from, Task& out) {
 }
 
 void Scheduler::onBeginSpinning(int workerId) {
-  auto idx = nextSpinningWorkerIdx++ % spinningWorkers.size();
+  auto idx = nextSpinningWorkerIdx++ % cfg.workerThread.count;
   spinningWorkers[idx] = workerId;
 }
 
@@ -572,7 +570,7 @@ void Scheduler::Worker::run() {
     MARL_NAME_THREAD("Thread<%.2d> Fiber<%.2d>", int(id), Fiber::current()->id);
     // This is the entry point for a multi-threaded worker.
     // Start with a regular condition-variable wait for work. This avoids
-    // starting the thread with a spinForWork().
+    // starting the thread with a spinForWorkAndLock().
     work.wait([this]() REQUIRES(work.mutex) {
       return work.num > 0 || work.waiting || shutdown;
     });
@@ -599,8 +597,7 @@ void Scheduler::Worker::waitForWork() {
   if (mode == Mode::MultiThreaded) {
     scheduler->onBeginSpinning(id);
     work.mutex.unlock();
-    spinForWork();
-    work.mutex.lock();
+    spinForWorkAndLock();
   }
 
   work.wait([this]() REQUIRES(work.mutex) {
@@ -637,7 +634,7 @@ void Scheduler::Worker::setFiberState(Fiber* fiber, Fiber::State to) const {
   fiber->state = to;
 }
 
-void Scheduler::Worker::spinForWork() {
+void Scheduler::Worker::spinForWorkAndLock() {
   TRACE("SPIN");
   Task stolen;
 
@@ -652,13 +649,21 @@ void Scheduler::Worker::spinForWork() {
       nop(); nop(); nop(); nop(); nop(); nop(); nop(); nop();
       nop(); nop(); nop(); nop(); nop(); nop(); nop(); nop();
       // clang-format on
+
       if (work.num > 0) {
-        return;
+        work.mutex.lock();
+        if (work.num > 0) {
+          return;
+        }
+        else {
+          // Our new task was stolen by another worker. Keep spinning.
+          work.mutex.unlock();
+        }
       }
     }
 
     if (scheduler->stealWork(this, rng(), stolen)) {
-      marl::lock lock(work.mutex);
+      work.mutex.lock();
       work.tasks.emplace_back(std::move(stolen));
       work.num++;
       return;
@@ -666,6 +671,7 @@ void Scheduler::Worker::spinForWork() {
 
     std::this_thread::yield();
   }
+  work.mutex.lock();
 }
 
 void Scheduler::Worker::runUntilIdle() {


### PR DESCRIPTION
This pull request significantly improves performance in some cases, and it addresses the issue discussed here:
https://github.com/google/marl/issues/232

### The Problem:
A single worker will often do multiple tasks serially while other workers are idle. The task does not need to be of short duration. A single worker could do two tasks that take multiple seconds each while other workers continue to sleep. This problem is especially common with the fork-and-join pattern. Suppose you wait for N workers to finish their last task, so that you now have N workers that are spinning for work. Then suppose you enqueue N new tasks. The problem is that some of the workers are likely to go to sleep prematurely, while the N tasks are performed by < N worker threads.

### The Results:
This problem can be demonstrated with the following example code, which I instrumented using the Tracy profiler (https://github.com/wolfpld/tracy):
```
  constexpr int threadCount = 8;
  constexpr int repeatCount = 8;
  marl::Scheduler::Config cfg;
  cfg.workerThread.count = threadCount;
  marl::Scheduler scheduler(cfg);
  for (int repeat = 0; repeat < repeatCount; ++repeat) {
    marl::WaitGroup wg;
    for (int i = 0; i < threadCount; ++i) {
      wg.add(1);
      scheduler.enqueue(marl::Task{[wg]() {
        ZoneScopedN("DoTask");
        std::this_thread::sleep_for(std::chrono::milliseconds(10));
        wg.done();
      }});
    }
    wg.wait();
  }
```

A typical run of this code on my 32-core AMD Threadripper looks like this:
![marl_trace_before](https://github.com/google/marl/assets/74331473/848a1778-b1e4-46d6-af1e-05ccaa5b7344)

In this example, we had 8 worker threads and we enqueued 8 tasks at a time. Ideally each task would run on a different worker thread so that they all execute concurrently. However, as you can see from the above image, a single worker often ends up doing multiple tasks while other worker(s) are idle. Here is what it looks like after applying the changes in this PR:
![marl_trace_after](https://github.com/google/marl/assets/74331473/5d6907c6-c08a-4401-8146-bfd7ced94c4b)

The difference in performance is also seen in the new benchmark, which is included in this PR. Here are the results for my 32-core AMD Threadripper:
```
BEFORE:
--------------------------------------------------------------------------------------------
Benchmark                                                  Time             CPU   Iterations
--------------------------------------------------------------------------------------------
Schedule/MultipleForkAndJoin/tasks:512/threads:0  14460951100 ns   14453125000 ns            1
Schedule/MultipleForkAndJoin/tasks:512/threads:1  14369679600 ns        0.000 ns            1
Schedule/MultipleForkAndJoin/tasks:512/threads:2  7483740600 ns        0.000 ns            1
Schedule/MultipleForkAndJoin/tasks:512/threads:4  4574613900 ns        0.000 ns            1
Schedule/MultipleForkAndJoin/tasks:512/threads:8  2448965490 ns        0.000 ns           10
Schedule/MultipleForkAndJoin/tasks:512/threads:16 1835931720 ns      1562500 ns           10
Schedule/MultipleForkAndJoin/tasks:512/threads:32  947968840 ns      3125000 ns           10
Schedule/MultipleForkAndJoin/tasks:512/threads:64  511230270 ns        0.000 ns           10

AFTER:
--------------------------------------------------------------------------------------------
Benchmark                                                  Time             CPU   Iterations
--------------------------------------------------------------------------------------------
Schedule/MultipleForkAndJoin/tasks:512/threads:0  14724095300 ns   14656250000 ns            1
Schedule/MultipleForkAndJoin/tasks:512/threads:1  14939546400 ns     15625000 ns            1
Schedule/MultipleForkAndJoin/tasks:512/threads:2  7732024900 ns     15625000 ns            1
Schedule/MultipleForkAndJoin/tasks:512/threads:4  3668345300 ns        0.000 ns            1
Schedule/MultipleForkAndJoin/tasks:512/threads:8  1936010700 ns      3125000 ns           10
Schedule/MultipleForkAndJoin/tasks:512/threads:16  981641520 ns        0.000 ns           10
Schedule/MultipleForkAndJoin/tasks:512/threads:32  778781590 ns      4687500 ns           10
Schedule/MultipleForkAndJoin/tasks:512/threads:64  489064570 ns        0.000 ns           10
```

And here are the benchmark results measured on my Macbook Pro with 10 core M1 MAX:
```
BEFORE:
--------------------------------------------------------------------------------------------
Benchmark                                                  Time             CPU   Iterations
--------------------------------------------------------------------------------------------
Schedule/MultipleForkAndJoin/tasks:512/threads:0  2.0409e+10 ns   2.0406e+10 ns            1
Schedule/MultipleForkAndJoin/tasks:512/threads:1  2.0370e+10 ns      2677000 ns            1
Schedule/MultipleForkAndJoin/tasks:512/threads:2  1.0619e+10 ns      1660000 ns            1
Schedule/MultipleForkAndJoin/tasks:512/threads:4  6006134250 ns      1007000 ns            1
Schedule/MultipleForkAndJoin/tasks:512/threads:8  5090412292 ns      1211000 ns            1
Schedule/MultipleForkAndJoin/tasks:512/threads:10 4149048084 ns      1398000 ns            1

AFTER:
--------------------------------------------------------------------------------------------
Benchmark                                                  Time             CPU   Iterations
--------------------------------------------------------------------------------------------
Schedule/MultipleForkAndJoin/tasks:512/threads:0  2.0393e+10 ns   2.0392e+10 ns            1
Schedule/MultipleForkAndJoin/tasks:512/threads:1  2.0420e+10 ns      2813000 ns            1
Schedule/MultipleForkAndJoin/tasks:512/threads:2  1.0520e+10 ns      1683000 ns            1
Schedule/MultipleForkAndJoin/tasks:512/threads:4  5403471458 ns       963000 ns            1
Schedule/MultipleForkAndJoin/tasks:512/threads:8  4604350166 ns      1697000 ns            1
Schedule/MultipleForkAndJoin/tasks:512/threads:10 3125431250 ns      1866000 ns            1
```

### Explanation of the Problem:
1) There were two race conditions in the `spinForWork` function. While spinning, it might discover that `(work.num > 0)`, indicating that new work was assigned to it. It would then stop spinning, then try to lock the mutex, then discover that `(work.num == 0)` because another spinning worker stole the task from it. With no tasks to perform, the thread would then go to sleep. It should have continued spinning until it had a task (that could not be stolen from it), or until the timeout. Meanwhile, the `enqueue` function may have assigned a task to the same worker that just stole a task. That worker will end up with two tasks and the other worker will be asleep.

2) The second race condition was similar. While spinning for work, one thread might successfully steal work from another. It would then stop spinning, then lock the mutex, then discover that `(work.num == 0)` because the work was stolen from it. With no work, the thread would then go to sleep. Again, it should have continued spinning until it had work or until the timeout. I have observed that it is actually quite common for a task to be stolen multiple times in a row, when there are several spinning workers.

3) It is also possible for the `enqueue` function to assign a new task to a thread that already has work to do. This can happen while there other worker threads are asleep. If there are no spinning workers, then nobody can steal the extra task(s). This is another situation where one worker may spend a long time working on serial tasks while other workers sleep.

### Solutions:
* To address the race conditions (problems 1 & 2 above), I replaced `spinForWork` with `spinForWorkAndLock`. As the name suggests, it now acquires the mutex lock before returning. If it detects that `(work.num > 0)` or if it successfully steals a task, then it will return while holding the lock. This guarantees that the thread will not stop spinning until it has a task that cannot be stolen, or until the timeout is reached.
* In order to completely fix problem 3 (above), the `enqueue` function would need to do more work to ensure that it has found the best thread for the new task. That would add cost, so I didn't do it. Instead, I increased the size of the `spinningWorkers` queue. Previously, it would only remember the last 8 workers that started spinning. Now, the `spinningWorkers` queue can be as large as the number of worker threads. Thus, if N threads start spinning, then the `spinningWorkers` queue will have N unique thread indices. The next N tasks that are enqueued will attempt to use those spinning workers. I believe this results in a better distribution of work than using `nextEnqueueIndex`. Unfortunately, this solution is not bullet proof. For example, the `spinningWorkers` queue might point to a worker that is not actually spinning because that worker might have successfully stolen a task. Or, the `try_lock` might fail, causing the `enqueue` function to fall back on `nextEnqueueIndex`.