### PR TITLE
Make implicit `this` capture explicit

### DIFF
--- a/src/scheduler.cpp
+++ b/src/scheduler.cpp
@@ -367,7 +367,7 @@ void Scheduler::Worker::start() {
       auto allocator = scheduler->cfg.allocator;
       auto& affinityPolicy = scheduler->cfg.workerThread.affinityPolicy;
       auto affinity = affinityPolicy->get(id, allocator);
-      thread = Thread(std::move(affinity), [=] {
+      thread = Thread(std::move(affinity), [=, this] {
         Thread::setName("Thread<%.2d>", int(id));
 
         if (auto const& initFunc = scheduler->cfg.workerThread.initializer) {


### PR DESCRIPTION
When declaring a lambda with a value-capture default `[=, ...]`, the `this` pointer is implicitly captured by value as well. This results in potentially-unintuitive behavior (https://reviews.llvm.org/D142639) and produces a warning in newer versions of clang.

This commit simply makes the implicit capture explicit, preventing the warning.