### PR TITLE
kokoro: linux: update to gcc-13, cmake 3.31.2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -356,6 +356,12 @@ if(MARL_BUILD_TESTS)
         ${MARL_GOOGLETEST_DIR}/googlemock/src/gmock-all.cc
     )
 
+    # Disable warnings for third party code
+    set_property(SOURCE
+        ${MARL_GOOGLETEST_DIR}/googletest/src/gtest-all.cc
+        ${MARL_GOOGLETEST_DIR}/googlemock/src/gmock-all.cc
+	APPEND PROPERTY COMPILE_OPTIONS -w)
+
     set(MARL_TEST_INCLUDE_DIR
         ${MARL_GOOGLETEST_DIR}/googletest/include/
         ${MARL_GOOGLETEST_DIR}/googlemock/include/

--- a/kokoro/ubuntu/docker.sh
+++ b/kokoro/ubuntu/docker.sh
@@ -29,10 +29,10 @@ function status {
 . /bin/using.sh # Declare the bash `using` function for configuring toolchains.
 
 status "Setting up environment"
-using gcc-9 # Always update gcc so we get a newer standard library.
+using gcc-13 # Always update gcc so we get a newer standard library.
 
 if [ "$BUILD_SYSTEM" == "cmake" ]; then
-    using cmake-3.17.2
+    using cmake-3.31.2
 
     SRC_DIR=$(pwd)
     BUILD_DIR=/tmp/marl-build


### PR DESCRIPTION
Also disable warnings in third party code in googletest and googlemock