### PR TITLE
Explicitly capture 'this' only for C++20 and later

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,7 @@ cmake_minimum_required(VERSION 3.0)
 include(cmake/parse_version.cmake)
 parse_version("${CMAKE_CURRENT_SOURCE_DIR}/CHANGES.md" MARL)
 
+# Marl only needs C++11, but it has sometimes been tested with C++20
 set(CMAKE_CXX_STANDARD 11)
 
 project(Marl

--- a/examples/fractal.cpp
+++ b/examples/fractal.cpp
@@ -22,7 +22,7 @@
 
 #include <fstream>
 
-#include <math.h>
+#include <cmath>
 #include <stdint.h>
 
 // A color formed from a red, green and blue component.

--- a/examples/primes.cpp
+++ b/examples/primes.cpp
@@ -20,6 +20,7 @@
 #include "marl/thread.h"
 #include "marl/ticket.h"
 
+#include <cstdio>
 #include <vector>
 
 #include <math.h>

--- a/include/marl/dag.h
+++ b/include/marl/dag.h
@@ -24,6 +24,12 @@
 #include "scheduler.h"
 #include "waitgroup.h"
 
+#if __cplusplus > 201703L
+#define CAPTURE_THIS , this
+#else
+#define CAPTURE_THIS
+#endif
+
 namespace marl {
 namespace detail {
 using DAGCounter = std::atomic<uint32_t>;
@@ -188,7 +194,7 @@ void DAGBase<T>::invoke(RunContext* ctx, NodeIndex nodeIdx, WaitGroup* wg) {
         // reference to a value. This ensures that the WaitGroup isn't dropped
         // while in use.
         schedule(
-            [=](WaitGroup wg) {
+            [= CAPTURE_THIS](WaitGroup wg) {
               invoke(ctx, toInvoke, &wg);
               wg.done();
             },
@@ -406,5 +412,7 @@ void DAG<void>::run(Allocator* allocator /* = Allocator::Default */) {
 }
 
 }  // namespace marl
+
+#undef CAPTURE_THIS
 
 #endif  // marl_dag_h

--- a/src/scheduler.cpp
+++ b/src/scheduler.cpp
@@ -48,6 +48,14 @@
               "fiber %d was in state %s, but expected %s", (int)FIBER->id, \
               Fiber::toString(FIBER->state), Fiber::toString(STATE))
 
+// In C++20, lambda capture [=] will not also capture 'this'. Do it explicitly
+// if using C++20
+#if __cplusplus > 201703L
+#define CAPTURE_THIS , this
+#else
+#define CAPTURE_THIS
+#endif
+
 namespace {
 
 #if ENABLE_DEBUG_LOGGING
@@ -367,7 +375,7 @@ void Scheduler::Worker::start() {
       auto allocator = scheduler->cfg.allocator;
       auto& affinityPolicy = scheduler->cfg.workerThread.affinityPolicy;
       auto affinity = affinityPolicy->get(id, allocator);
-      thread = Thread(std::move(affinity), [=, this] {
+      thread = Thread(std::move(affinity), [= CAPTURE_THIS] {
         Thread::setName("Thread<%.2d>", int(id));
 
         if (auto const& initFunc = scheduler->cfg.workerThread.initializer) {


### PR DESCRIPTION
This reverts commit 690889fbb816a409b4fcd4bdf60e32a4deebeb08.

Fixes build failures on current compilers.

Fixes: #271